### PR TITLE
chore: Mention bundled FlatBuffers in LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -200,3 +200,13 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+--------------------------------------------------------------------------------
+This product includes code from FlatBuffers:
+
+* src/Apache.Arrow/Flatbuf/FlatBuffers/
+
+Copyright: (C) 2014 Google Inc.
+Home page: https://github.com/google/flatbuffers/
+Origin: https://github.com/google/flatbuffers/tree/v23.5.9/net/FlatBuffers
+License: https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
## What's Changed

It's not required but it's better to mention it:

https://infra.apache.org/licensing-howto.html#alv2-dep

> Bundling an Apache 2-0-licensed dependency
>
> Assuming that the bundled dependency itself contains no bundled sub-components under other licenses, so the ALv2 applies uniformly to all files, there is no need to modify LICENSE. However, for completeness it is useful to list the products and their versions, as is done for products under other licenses.
>
> If the dependency supplies a NOTICE file, its contents must be analyzed and the relevant portions bubbled up into the top-level NOTICE file.

Closes #22.
