### PR TITLE
chore: Prepare https://arrow.apache.org/dotnet/

### DIFF
--- a/.github/workflows/pr_comment.yaml
+++ b/.github/workflows/pr_comment.yaml
@@ -43,10 +43,10 @@ jobs:
           fork_owner=${FORK_REPOSITORY%/*}
           fork_repository=${FORK_REPOSITORY#*/}
           {
-            echo "Preview URL: https://${fork_owner}.github.io/${fork_repository}"
+            echo "Documentation preview URL: https://${fork_owner}.github.io/${fork_repository}"
             echo ""
-            echo "If the preview URL doesn't work, you may forget to configure your fork repository for preview."
-            echo "See ${configure_url} how to configure."
+            echo "If the preview URL doesn't work, you may need to configure your fork repository for preview."
+            echo "See ${configure_url} for instructions on how to configure."
           } | tee body.md
           gh pr comment ${PR_NUMBER} \
             --body-file body.md \

--- a/.github/workflows/pr_comment.yaml
+++ b/.github/workflows/pr_comment.yaml
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: PR comment
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  preview-url:
+    name: Preview URL
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
+          FORK_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          configure_url="https://github.com/apache/arrow-dotnet/blob/main/docs/README.md#preview-on-forks"
+          fork_owner=${FORK_REPOSITORY%/*}
+          fork_repository=${FORK_REPOSITORY#*/}
+          {
+            echo "Preview URL: https://${fork_owner}.github.io/${fork_repository}"
+            echo ""
+            echo "If the preview URL doesn't work, you may forget to configure your fork repository for preview."
+            echo "See ${configure_url} how to configure."
+          } | tee body.md
+          gh pr comment ${PR_NUMBER} \
+            --body-file body.md \
+            --repo ${PR_REPOSITORY}

--- a/.github/workflows/rc.yaml
+++ b/.github/workflows/rc.yaml
@@ -170,9 +170,80 @@ jobs:
           mv release-*/* ./
           dev/release/verify_rc.sh "${VERSION}" "${RC}"
 
+  docs:
+    name: Documentation
+    needs:
+      - target
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      RC: ${{ needs.target.outputs.rc }}
+      VERSION: ${{ needs.target.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Build documentation
+        shell: bash
+        run: ci/scripts/docs.sh $(pwd)
+      - name: Package
+        run: |
+          id="apache-arrow-dotnet-docs-${VERSION}"
+          tar_gz="${id}.tar.gz"
+          mv docs/_site "${id}"
+          tar czf "${tar_gz}" "${id}"
+          sha256sum "${tar_gz}" > "${tar_gz}.sha256"
+          sha512sum "${tar_gz}" > "${tar_gz}.sha512"
+      - name: Upload
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-docs
+          path: |
+            apache-arrow-dotnet-docs-*.tar.gz*
+      - name: Upload pages
+        if: |
+          github.event_name == 'push' &&
+          github.repository != 'apache/arrow-dotnet'
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        with:
+          path: apache-arrow-dotnet-docs-${{ env.VERSION }}
+      - name: Deploy for production
+        if: |
+          github.event_name == 'push' &&
+          github.repository == 'apache/arrow-dotnet' &&
+          github.ref_name == 'main'
+        run: |
+          ci/scripts/update_site.sh "${VERSION}"
+          cd site
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if [ "$(git diff --cached)" != "" ]; then
+            git commit -m "Update docs for ${GITHUB_SHA}"
+            git push origin "$(git branch --show-current)"
+          fi
+
+  docs-deploy-fork:
+    name: Deploy on fork
+    if: >-
+      github.event_name == 'push' &&
+      github.repository != 'apache/arrow-dotnet'
+    needs:
+        - docs
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+
   upload:
     name: Upload
     needs:
+      - docs
       - target
       - verify
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,3 +57,31 @@ jobs:
             --title "Apache Arrow .NET ${version}" \
             --verify-tag \
             dists/*
+      - name: Checkout asf-site
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: asf-site
+          path: site
+      - name: Update documentation
+        run: |
+          version=${GITHUB_REF_NAME#v}
+          tar_gz=${PWD}/dists/apache-arrow-dotnet-docs-${version}.tar.gz
+
+          pushd site
+
+          rm -rf current
+          mkdir -p current
+          pushd current
+          tar xf "${tar_gz}" --strip-components=1
+          popd
+          git add current
+
+          rm -rf "${version}"
+          cp -a current "${version}"
+          git add "${version}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git commit -m "Update docs for ${version}"
+          git push origin "$(git branch --show-current)"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -83,14 +83,3 @@ jobs:
       - name: Test
         shell: bash
         run: ci/scripts/test.sh $(pwd)
-
-  docs:
-    name: Build Documentation
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: Build documentation
-        shell: bash
-        run: ci/scripts/docs.sh $(pwd)

--- a/ci/scripts/update_site.sh
+++ b/ci/scripts/update_site.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -exu
+
+version="${1}"
+
+html_escape() {
+  # & -> &amp; must be the first substitution
+  sed -e "s/&/&amp;/g" \
+    -e "s/</&lt;/g" \
+    -e "s/>/&gt;/g" \
+    -e "s/\"/&quot;/g" \
+    -e "s/'/&apos;/g"
+}
+
+if ! git fetch origin asf-site; then
+  git worktree add --orphan -b asf-site site
+else
+  git worktree add site -B asf-site origin/asf-site
+fi
+
+tar_gz="${PWD}/apache-arrow-dotnet-docs-${version}.tar.gz"
+
+extract_docs() {
+  local destination="${1}"
+
+  rm -rf "${destination}"
+  mkdir -p "${destination}"
+  pushd "${destination}"
+  tar xf "${tar_gz}" --strip-components=1
+  popd
+  git add "${destination}"
+}
+
+pushd site
+# Synchronize .asf.yaml
+cp -a ../.asf.yaml ./
+git add .asf.yaml
+
+# Update https://arrow.apache.org/dotnet/main/
+extract_docs main
+
+# Create .htaccess
+cat >.htaccess <<HTACCESS
+RedirectMatch "^/dotnet/$" "/dotnet/current/"
+HTACCESS
+git add .htaccess
+popd

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,42 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Docs
+
+## Preview on fork
+
+When implementing changes to the website on a fork, the GitHub Actions
+workflow behaves differently.
+
+On a commit to all branches, the rendered static site will be
+published to GitHub Pages using GitHub Actions. The latest commit is
+only visible because all publications use the same output location:
+https://${YOUR_GITHUB_ACCOUNT}.github.io/arrow-dotnet/
+
+You need to configure your fork repository to use this feature:
+
+1. Enable GitHub Pages on your fork:
+   1. Open https://github.com/${YOUR_GITHUB_ACCOUNT}/arrow-dotnet/settings/pages
+   2. Select "GitHub Actions" as "Source"
+2. Accept publishing GitHub Pages from all branches on your fork:
+   1. Open https://github.com/${YOUR_GITHUB_ACCOUNT}/arrow-dotnet/settings/environments
+   2. Select the "github-pages" environment
+   3. Change the default "Deployment branches and tags" rule:
+      1. Press the "Edit" button
+      2. Change the "Name pattern" to `*` from `main` or `gh-pages`
+
+See also the [GitHub Pages documentation](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow).

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -23,6 +23,7 @@
           "**/*.{md,yml}"
         ],
         "exclude": [
+          "README.md",
           "_site/**",
           "images/**"
         ]


### PR DESCRIPTION
## What's Changed

Add support for publishing to https://arrow.apache.org/dotnet/ : 
* The `main` branch -> https://arrow.apache.org/dotnet/main/
* The `vX.Y.Z` tag -> https://arrow.apache.org/dotnet/X.Y.Z/
* The latest `vX.Y.Z` tag -> https://arrow.apache.org/dotnet/current/
* https://arrow.apache.org/dotnet/ -> https://arrow.apache.org/dotnet/current/

Add support for previewing on fork: https://${GITHUB_ID}.github.io/arrow-dotnet/
Example: https://kou.github.io/arrow-dotnet/

See docs/README.md how to prepare fork to preview.

Add support for commenting preview URL on PR.

Closes #26.
