### PR TITLE
chore: Fix permission error on deploying main docs

### DIFF
--- a/.github/workflows/rc.yaml
+++ b/.github/workflows/rc.yaml
@@ -97,8 +97,6 @@ jobs:
     env:
       RC: ${{ needs.target.outputs.rc }}
       VERSION: ${{ needs.target.outputs.version }}
-    permissions:
-      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -179,6 +177,8 @@ jobs:
     env:
       RC: ${{ needs.target.outputs.rc }}
       VERSION: ${{ needs.target.outputs.version }}
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
## What's Changed

We need `permissions: contents: write` to push the `asf-site` branch.

We don't need `contents: write` for the `package` job.

Closes #37.
