### PR TITLE
feat: Bounds checking for Flatbuf should be enabled in the default build

### DIFF
--- a/src/Apache.Arrow/Apache.Arrow.csproj
+++ b/src/Apache.Arrow/Apache.Arrow.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants>$(DefineConstants);UNSAFE_BYTEBUFFER;BYTEBUFFER_NO_BOUNDS_CHECK;ENABLE_SPAN_T</DefineConstants>
+    <DefineConstants>$(DefineConstants);UNSAFE_BYTEBUFFER;ENABLE_SPAN_T</DefineConstants>
     
     <Description>Apache Arrow is a cross-language development platform for in-memory data. It specifies a standardized language-independent columnar memory format for flat and hierarchical data, organized for efficient analytic operations on modern hardware.</Description>
   </PropertyGroup>

--- a/src/Apache.Arrow/Flatbuf/FlatBuffers/ByteBuffer.cs
+++ b/src/Apache.Arrow/Flatbuf/FlatBuffers/ByteBuffer.cs
@@ -693,6 +693,7 @@ namespace Google.FlatBuffers
 #if ENABLE_SPAN_T && UNSAFE_BYTEBUFFER
         public unsafe string GetStringUTF8(int startPos, int len)
         {
+            AssertOffsetAndLength(startPos, len);
             fixed (byte* buffer = &MemoryMarshal.GetReference(_buffer.ReadOnlySpan.Slice(startPos)))
             {
                 return Encoding.UTF8.GetString(buffer, len);

--- a/test/Apache.Arrow.Benchmarks/ArrowWriterBenchmark.cs
+++ b/test/Apache.Arrow.Benchmarks/ArrowWriterBenchmark.cs
@@ -25,10 +25,10 @@ namespace Apache.Arrow.Benchmarks
     [MemoryDiagnoser]
     public class ArrowWriterBenchmark
     {
-        [Params(10_000, 1_000_000)]
+        [Params(10_000, 300_000)]
         public int BatchLength { get; set; }
 
-        //Max column set count is 15 before reaching 2gb limit of memory stream
+        //Max column set count is 14 before reaching 2gb limit of memory stream
         [Params(10, 14)]
         public int ColumnSetCount { get; set; }
 

--- a/test/Apache.Arrow.Tests/TestData.cs
+++ b/test/Apache.Arrow.Tests/TestData.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data.SqlTypes;
 using System.Linq;
 using Apache.Arrow.Arrays;
 using Apache.Arrow.Scalars;
@@ -201,7 +202,8 @@ namespace Apache.Arrow.Tests
 
                 for (var i = 0; i < Length; i++)
                 {
-                    builder.Append((decimal)i / Length);
+                    SqlDecimal value = SqlDecimal.ConvertToPrecScale((decimal)i / Length, type.Precision, type.Scale);
+                    builder.Append((decimal)value);
                 }
 
                 Array = builder.Build();
@@ -213,7 +215,8 @@ namespace Apache.Arrow.Tests
 
                 for (var i = 0; i < Length; i++)
                 {
-                    builder.Append((decimal)i / Length);
+                    SqlDecimal value = SqlDecimal.ConvertToPrecScale((decimal)i / Length, type.Precision, type.Scale);
+                    builder.Append((decimal)value);
                 }
 
                 Array = builder.Build();
@@ -225,7 +228,8 @@ namespace Apache.Arrow.Tests
 
                 for (var i = 0; i < Length; i++)
                 {
-                    builder.Append((decimal)i / Length);
+                    SqlDecimal value = SqlDecimal.ConvertToPrecScale((decimal)i / Length, type.Precision, type.Scale);
+                    builder.Append((decimal)value);
                 }
 
                 Array = builder.Build();
@@ -237,7 +241,8 @@ namespace Apache.Arrow.Tests
 
                 for (var i = 0; i < Length; i++)
                 {
-                    builder.Append((decimal)i / Length);
+                    SqlDecimal value = SqlDecimal.ConvertToPrecScale((decimal)i / Length, type.Precision, type.Scale);
+                    builder.Append((decimal)value);
                 }
 
                 Array = builder.Build();


### PR DESCRIPTION
## What's Changed

Enables bounds checking for Flatbuf as input can't generally be trusted.
Adds a test for a malformed column name length.
Makes some fixes required to be able to benchmark the change and demonstrate that there's no significant regression.

Closes #48.