### PR TITLE
chore: Bump version to 22.0.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,7 @@
     <Product>Apache Arrow library</Product>
     <Copyright>Copyright 2016-2024 The Apache Software Foundation</Copyright>
     <Company>The Apache Software Foundation</Company>
-    <Version>22.0.0</Version>
+    <Version>22.0.1</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## What's Changed

There are only backward compatible bug fixes for the next release.

#57
