### PR TITLE
fix: When removing GC memory pressure, incorporate the default alignment

### DIFF
--- a/src/Apache.Arrow/Memory/NativeMemoryAllocator.cs
+++ b/src/Apache.Arrow/Memory/NativeMemoryAllocator.cs
@@ -55,7 +55,7 @@ namespace Apache.Arrow.Memory
             public void Release(IntPtr ptr, int offset, int length)
             {
                 Marshal.FreeHGlobal(ptr);
-                GC.RemoveMemoryPressure(length);
+                GC.RemoveMemoryPressure(length + DefaultAlignment); // See https://github.com/apache/arrow-dotnet/issues/50
             }
         }
     }


### PR DESCRIPTION
## What's Changed

When removing the memory pressure on the .NET garbage collector, assume that the native allocation used the default alignment. Ideally we'd remember the specific alignment used so we could produce an exact result, but the bookkeeping doesn't seem worthwhile.

References #50.