### PR TITLE
Fix uninitialized memory in C API

### DIFF
--- a/src/Apache.Arrow/C/CArrowArrayExporter.cs
+++ b/src/Apache.Arrow/C/CArrowArrayExporter.cs
@@ -184,6 +184,7 @@ namespace Apache.Arrow.C
 
             cArray->n_buffers = 1;
             cArray->buffers = (byte**)sharedOwner.Allocate(IntPtr.Size);
+            cArray->buffers[0] = null;
 
             cArray->n_children = batch.ColumnCount;
             cArray->children = null;


### PR DESCRIPTION
`AllocHGlobal` does not zero-initialize the memory it allocates. This change fixes the `RecordBatch` exporter to correctly set the "nulls" buffer to be null instead of inheriting what it got from allocation.