### PR TITLE
chore: Update MacOS runners to macos-latest

### DIFF
--- a/.github/workflows/rc.yaml
+++ b/.github/workflows/rc.yaml
@@ -140,7 +140,7 @@ jobs:
         dotnet-version:
           - 8.0.x
         runs-on:
-          - macos-13
+          - macos-latest
           - ubuntu-latest
           - windows-latest
     env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,7 +63,7 @@ jobs:
         dotnet-version:
           - 8.0.x
         runs-on:
-          - macos-13
+          - macos-latest
           - ubuntu-latest
           - windows-latest
     steps:


### PR DESCRIPTION
## What's Changed

Updates the version of the MacOS runners used in GitHub actions to `macos-latest` as `macos-13` runners are deprecated.

Closes #116.
