### PR TITLE
chore: Fix version detection

### DIFF
--- a/dev/release/release.sh
+++ b/dev/release/release.sh
@@ -46,8 +46,8 @@ fi
 
 cd "${SOURCE_TOP_DIR}"
 
-version=$(grep -E -o '<Version>(.*)</Version>' Directory.Build.props |
-  sed -E -e 's,</?Version>,,g')
+version=$(grep -E -o '<VersionPrefix>(.*)</VersionPrefix>' Directory.Build.props |
+  sed -E -e 's,</?VersionPrefix>,,g')
 
 git_origin_url="$(git remote get-url origin)"
 repository="${git_origin_url#*github.com?}"

--- a/dev/release/release_rc.sh
+++ b/dev/release/release_rc.sh
@@ -46,8 +46,8 @@ fi
 
 cd "${SOURCE_TOP_DIR}"
 
-version=$(grep -E -o '<Version>(.*)</Version>' Directory.Build.props |
-  sed -E -e 's,</?Version>,,g')
+version=$(grep -E -o '<VersionPrefix>(.*)</VersionPrefix>' Directory.Build.props |
+  sed -E -e 's,</?VersionPrefix>,,g')
 
 if [ "${RELEASE_PULL}" -gt 0 ] || [ "${RELEASE_PUSH_TAG}" -gt 0 ]; then
   git_origin_url="$(git remote get-url origin)"


### PR DESCRIPTION
## What's Changed

We should use `<VersionPrefix>` not `<Version>` because GH-114 changed the tag.

Closes #126.
