### PR TITLE
Use a license expression for the NuGet package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
   <PropertyGroup>
     <Authors>The Apache Software Foundation</Authors>
     <PackageIcon>logo_asf.png</PackageIcon>
-    <PackageLicenseExpression>APACHE-2.0</PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://arrow.apache.org/</PackageProjectUrl>
     <PackageTags>apache arrow</PackageTags>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
## What's Changed

Use a standard `PackageLicenseExpression` instead of a license file when publishing the NuGet package.