### PR TITLE
Use unsigned long integers for computing bit-length of fixed-width types via the CData ABI

### DIFF
--- a/src/Apache.Arrow/C/CArrowArrayImporter.cs
+++ b/src/Apache.Arrow/C/CArrowArrayImporter.cs
@@ -470,7 +470,10 @@ namespace Apache.Arrow.C
                 int length = checked((int)cArray->offset + (int)cArray->length);
                 int valuesLength;
                 if (bitWidth >= 8)
+                {
+                    Debug.Assert(bitWidth % 8 == 0);
                     valuesLength = checked((int)((ulong)length * (ulong)bitWidth / 8ul));
+                }
                 else
                     valuesLength = checked((int)BitUtility.RoundUpToMultipleOf8(length) / 8);
 


### PR DESCRIPTION
## What's Changed

Uses unsigned 64-bit integers to compute the intermediate bit length of an array to avoid arithmetic overflow. 

I could factorize this expression differently to avoid the casts, but I didn't think this was a sufficiently heavy code path that it'd need more attention.

Closes #250 .
