### PR TITLE
chore: Add documentation preview URL to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,4 +10,4 @@ Closes #NNN.
 to publish the documentation to GitHub pages as described in
 https://github.com/apache/arrow-dotnet/blob/main/docs/README.md#preview-on-fork,
 and uncomment then edit the line below to correct the URL: -->
-<!-- Documentation preview: https://YOUR_GITHUB_USER.github.io/arrow-dotnet -->
+<!-- Documentation preview: https://${YOUR_GITHUB_ACCOUNT}.github.io/arrow-dotnet -->


### PR DESCRIPTION
Follow up to #255.

Adds a line to the PR template that users can edit and point to their documentation site if they're changing the docs.