### PR TITLE
chore: Fix test warnings about skipping duplicate test cases

### DIFF
--- a/test/Apache.Arrow.Tests/Date32ArrayTests.cs
+++ b/test/Apache.Arrow.Tests/Date32ArrayTests.cs
@@ -33,7 +33,7 @@ namespace Apache.Arrow.Tests
 
 #if NET6_0_OR_GREATER
         public static IEnumerable<object[]> GetDateOnlyData() =>
-            TestDateAndTimeData.ExampleDates.Select(d => new object[] { DateOnly.FromDateTime(d) });
+            TestDateAndTimeData.ExampleDateOnlyDates.Select(d => new object[] { d });
 #endif
 
         public class AppendNull

--- a/test/Apache.Arrow.Tests/Date64ArrayTests.cs
+++ b/test/Apache.Arrow.Tests/Date64ArrayTests.cs
@@ -35,7 +35,7 @@ namespace Apache.Arrow.Tests
 
 #if NET6_0_OR_GREATER
         public static IEnumerable<object[]> GetDateOnlyData() =>
-            TestDateAndTimeData.ExampleDates.Select(d => new object[] { DateOnly.FromDateTime(d) });
+            TestDateAndTimeData.ExampleDateOnlyDates.Select(d => new object[] { d });
 #endif
 
         public class AppendNull

--- a/test/Apache.Arrow.Tests/TestDateAndTimeData.cs
+++ b/test/Apache.Arrow.Tests/TestDateAndTimeData.cs
@@ -59,6 +59,15 @@ namespace Apache.Arrow.Tests
             from kind in _exampleKinds
             select DateTime.SpecifyKind(date, kind);
 
+#if NET6_0_OR_GREATER
+        /// <summary>
+        /// Gets a collection of example dates (i.e. with a zero time component) as DateOnly values.
+        /// </summary>
+        public static IEnumerable<DateOnly> ExampleDateOnlyDates =>
+            from date in _exampleDates
+            select DateOnly.FromDateTime(date);
+#endif
+
         /// <summary>
         /// Gets a collection of example times
         /// </summary>


### PR DESCRIPTION
`ExampleDates` contains dates as `DateTime` values with the same day number but different kind, and the kind is dropped when converting to `DateOnly`, so this leads to duplicate test data values.

This caused noisy test output with lots of warnings, eg.: https://github.com/apache/arrow-dotnet/actions/runs/22288974318/job/64472676225#step:6:74