### PR TITLE
Fixed issue #269

### DIFF
--- a/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -369,13 +369,21 @@ namespace Apache.Arrow
         }
 
         int IReadOnlyCollection<byte[]>.Count => Length;
-        byte[] IReadOnlyList<byte[]>.this[int index] => GetBytes(index).ToArray();
+        byte[] IReadOnlyList<byte[]>.this[int index]
+        {
+            get
+            {
+                var bytes = GetBytes(index, out bool isNull);
+                return isNull ? null : bytes.ToArray();
+            }
+        }
 
         IEnumerator<byte[]> IEnumerable<byte[]>.GetEnumerator()
         {
             for (int index = 0; index < Length; index++)
             {
-                yield return GetBytes(index).ToArray();
+                var bytes = GetBytes(index, out bool isNull);
+                yield return isNull ? null : bytes.ToArray();
             }
         }
 

--- a/test/Apache.Arrow.Tests/BinaryArrayBuilderTests.cs
+++ b/test/Apache.Arrow.Tests/BinaryArrayBuilderTests.cs
@@ -485,6 +485,14 @@ namespace Apache.Arrow.Tests
                 var actualArray = isNull ? null : actualSpan.ToArray();
                 Assert.Equal(expectedArray, actualArray);
             }
+
+            IReadOnlyList<byte[]> bytesArray = array;
+            for (int i = 0; i < bytesArray.Count; i++)
+            {
+                var expectedArray = expectedContentsArr[i];
+                var actualArray = bytesArray[i];
+                Assert.Equal(expectedArray, actualArray);
+            }
         }
     }
 }


### PR DESCRIPTION
## What's Changed

The implementation of `IReadOnlyList<byte[]>` on `BinaryArray` would return an empty byte array instead of null when the value was null. This has been fixed.

**This contains potentially-breaking changes, if consumers are not prepared to handle a null coming back from the IReadOnlyList**

Closes #269.
