### PR TITLE
Improvements to decimal conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -282,3 +282,5 @@ artifacts/
 
 # add .sln files back because they are ignored by the root .gitignore file
 !*.sln
+
+BenchmarkDotNet.Artifacts/

--- a/src/Apache.Arrow/Arrays/Decimal128Array.cs
+++ b/src/Apache.Arrow/Arrays/Decimal128Array.cs
@@ -147,6 +147,20 @@ namespace Apache.Arrow
             return DecimalUtility.GetDecimal(ValueBuffer, Offset + index, Scale, ByteWidth);
         }
 
+        public bool TryGetValue(int index, out decimal? value)
+        {
+            try
+            {
+                value = GetValue(index);
+                return true;
+            }
+            catch (OverflowException)
+            {
+                value = null;
+                return false;
+            }
+        }
+
         public IList<decimal?> ToList(bool includeNulls = false)
         {
             var list = new List<decimal?>(Length);

--- a/src/Apache.Arrow/Arrays/Decimal128Array.cs
+++ b/src/Apache.Arrow/Arrays/Decimal128Array.cs
@@ -138,6 +138,11 @@ namespace Apache.Arrow
         public int Precision => ((Decimal128Type)Data.DataType).Precision;
         public int ByteWidth => ((Decimal128Type)Data.DataType).ByteWidth;
 
+        /// <summary>
+        /// Gets the decimal value at the index of the array. May throw an exception if the value can't be
+        /// expressed as a <see cref="System.Decimal "/>. See <see cref="TryGetValue(int, out decimal?)" /> for
+        /// details.
+        /// </summary>
         public decimal? GetValue(int index)
         {
             if (IsNull(index))
@@ -147,6 +152,17 @@ namespace Apache.Arrow
             return DecimalUtility.GetDecimal(ValueBuffer, Offset + index, Scale, ByteWidth);
         }
 
+        /// <summary>
+        /// Gets the decimal value at the index of the array. Returns false if the value can't be
+        /// expressed as a <see cref="System.Decimal "/>. <see cref="System.Decimal "/> is a 128-bit
+        /// floating point value with a 5 bit base-10 exponent and a 96-bit base-10 mantissa. Decimal128
+        /// is a fixed point 128 bit value where up to 128 bits can be used for the mantissa, and both
+        /// the number of bits and the exponent are determined by the array's type (which is out-of-band).
+        /// This means that a <see cref="Decimal128Type"/> whose precision minus scale is greater than 28
+        /// might produce an overflow when stored as a .NET decimal. It may also cause rounding for
+        /// precisions greater than 28. These will silently succeed. By contrast, <see cref="SqlDecimal"/>
+        /// can store a decimal128 value with full fidelity.
+        /// </summary>
         public bool TryGetValue(int index, out decimal? value)
         {
             if (IsNull(index))

--- a/src/Apache.Arrow/Arrays/Decimal128Array.cs
+++ b/src/Apache.Arrow/Arrays/Decimal128Array.cs
@@ -149,16 +149,20 @@ namespace Apache.Arrow
 
         public bool TryGetValue(int index, out decimal? value)
         {
-            try
-            {
-                value = GetValue(index);
-                return true;
-            }
-            catch (OverflowException)
+            if (IsNull(index))
             {
                 value = null;
-                return false;
+                return true;
             }
+
+            if (DecimalUtility.TryGetDecimal(ValueBuffer, Offset + index, Scale, ByteWidth, out decimal result))
+            {
+                value = result;
+                return true;
+            }
+
+            value = null;
+            return false;
         }
 
         public IList<decimal?> ToList(bool includeNulls = false)

--- a/src/Apache.Arrow/Arrays/Decimal256Array.cs
+++ b/src/Apache.Arrow/Arrays/Decimal256Array.cs
@@ -156,6 +156,20 @@ namespace Apache.Arrow
             return DecimalUtility.GetDecimal(ValueBuffer, Offset + index, Scale, ByteWidth);
         }
 
+        public bool TryGetValue(int index, out decimal? value)
+        {
+            try
+            {
+                value = GetValue(index);
+                return true;
+            }
+            catch (OverflowException)
+            {
+                value = null;
+                return false;
+            }
+        }
+
         public IList<decimal?> ToList(bool includeNulls = false)
         {
             var list = new List<decimal?>(Length);

--- a/src/Apache.Arrow/Arrays/Decimal256Array.cs
+++ b/src/Apache.Arrow/Arrays/Decimal256Array.cs
@@ -158,16 +158,20 @@ namespace Apache.Arrow
 
         public bool TryGetValue(int index, out decimal? value)
         {
-            try
-            {
-                value = GetValue(index);
-                return true;
-            }
-            catch (OverflowException)
+            if (IsNull(index))
             {
                 value = null;
-                return false;
+                return true;
             }
+
+            if (DecimalUtility.TryGetDecimal(ValueBuffer, Offset + index, Scale, ByteWidth, out decimal result))
+            {
+                value = result;
+                return true;
+            }
+
+            value = null;
+            return false;
         }
 
         public IList<decimal?> ToList(bool includeNulls = false)

--- a/src/Apache.Arrow/Arrays/Decimal256Array.cs
+++ b/src/Apache.Arrow/Arrays/Decimal256Array.cs
@@ -146,6 +146,11 @@ namespace Apache.Arrow
         public int Precision => ((Decimal256Type)Data.DataType).Precision;
         public int ByteWidth => ((Decimal256Type)Data.DataType).ByteWidth;
 
+        /// <summary>
+        /// Gets the decimal value at the index of the array. May throw an exception if the value can't be
+        /// expressed as a <see cref="System.Decimal "/>. See <see cref="TryGetValue(int, out decimal?)" /> for
+        /// details.
+        /// </summary>
         public decimal? GetValue(int index)
         {
             if (IsNull(index))
@@ -156,6 +161,16 @@ namespace Apache.Arrow
             return DecimalUtility.GetDecimal(ValueBuffer, Offset + index, Scale, ByteWidth);
         }
 
+        /// <summary>
+        /// Gets the decimal value at the index of the array. Returns false if the value can't be
+        /// expressed as a <see cref="System.Decimal "/>. <see cref="System.Decimal "/> is a 128-bit
+        /// floating point value with a 5 bit base-10 exponent and a 96-bit base-10 mantissa. Decimal256
+        /// is a fixed point 256 bit value where up to 256 bits can be used for the mantissa, and both
+        /// the number of bits and the exponent are determined by the array's type (which is out-of-band).
+        /// This means that a <see cref="Decimal256Type"/> whose precision minus scale is greater than 28
+        /// might produce an overflow when stored as a .NET decimal. It may also cause rounding for
+        /// precisions greater than 28. These will silently succeed.
+        /// </summary>
         public bool TryGetValue(int index, out decimal? value)
         {
             if (IsNull(index))

--- a/src/Apache.Arrow/DecimalUtility.cs
+++ b/src/Apache.Arrow/DecimalUtility.cs
@@ -14,6 +14,9 @@
 // limitations under the License.
 
 using System;
+#if NET7_0_OR_GREATER
+using System.Buffers.Binary;
+#endif
 using System.Data.SqlTypes;
 using System.Numerics;
 
@@ -35,10 +38,117 @@ namespace Apache.Arrow
 
         private static int PowersOfTenLength => s_powersOfTen.Length - 1;
 
+#if NET7_0_OR_GREATER
+        // decimal mantissa is 96 bits unsigned
+        private static readonly UInt128 s_maxDecimalMantissa = new UInt128(0x0000_0000_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF);
+
+        private static readonly UInt128[] s_uint128PowersOfTen = ComputeUInt128Powers();
+
+        private static UInt128[] ComputeUInt128Powers()
+        {
+            var powers = new UInt128[39]; // 10^0 through 10^38
+            powers[0] = 1;
+            for (int i = 1; i < powers.Length; i++)
+                powers[i] = powers[i - 1] * 10;
+            return powers;
+        }
+#endif
+
         internal static decimal GetDecimal(in ArrowBuffer valueBuffer, int index, int scale, int byteWidth)
         {
             int startIndex = index * byteWidth;
             ReadOnlySpan<byte> value = valueBuffer.Span.Slice(startIndex, byteWidth);
+
+#if NET7_0_OR_GREATER
+            if (byteWidth == 16)
+            {
+                Int128 int128Value = BinaryPrimitives.ReadInt128LittleEndian(value);
+                return GetDecimalViaInt128(int128Value, scale);
+            }
+
+            if (byteWidth == 32)
+            {
+                // Check if the value fits in 128 bits (upper 128 bits are sign extension)
+                Int128 lower = BinaryPrimitives.ReadInt128LittleEndian(value);
+                Int128 upper = BinaryPrimitives.ReadInt128LittleEndian(value.Slice(16));
+                Int128 signExtension = lower < 0 ? Int128.NegativeOne : Int128.Zero;
+                if (upper == signExtension)
+                {
+                    return GetDecimalViaInt128(lower, scale);
+                }
+            }
+#endif
+
+            return GetDecimalViaBigInteger(value, scale);
+        }
+
+#if NET7_0_OR_GREATER
+        private static decimal GetDecimalViaInt128(Int128 integerValue, int scale)
+        {
+            bool negative = integerValue < 0;
+            UInt128 abs = negative ? (UInt128)(-integerValue) : (UInt128)integerValue;
+
+            // Fast path: value fits directly in decimal (96-bit mantissa, scale <= 28)
+            if (abs <= s_maxDecimalMantissa && scale <= 28)
+            {
+                return UInt128ToDecimal(abs, negative, (byte)scale);
+            }
+
+            if (scale == 0)
+            {
+                throw new OverflowException($"Value: {integerValue} is too large to be represented as a decimal");
+            }
+
+            // Split into integer and fractional parts
+            if (scale <= 38)
+            {
+                UInt128 scaleBy = s_uint128PowersOfTen[scale];
+                (UInt128 intPart, UInt128 fracPart) = UInt128.DivRem(abs, scaleBy);
+
+                if (intPart > s_maxDecimalMantissa)
+                {
+                    throw new OverflowException($"Value is too large to be represented as a decimal");
+                }
+
+                decimal intDecimal = UInt128ToDecimal(intPart, negative, 0);
+
+                // Reduce fractional part to fit decimal constraints
+                int fracScale = scale;
+                while (fracPart > s_maxDecimalMantissa || fracScale > 28)
+                {
+                    fracPart /= 10;
+                    fracScale--;
+                }
+
+                decimal fracDecimal = UInt128ToDecimal(fracPart, false, (byte)fracScale);
+                return negative ? intDecimal - fracDecimal : intDecimal + fracDecimal;
+            }
+            else
+            {
+                // scale > 38: abs < 2^127 < 10^39, so the integer part is 0 or very small.
+                // Reduce mantissa and scale together until they fit decimal constraints.
+                UInt128 mantissa = abs;
+                int decScale = scale;
+                while (mantissa > s_maxDecimalMantissa || decScale > 28)
+                {
+                    mantissa /= 10;
+                    decScale--;
+                }
+
+                return UInt128ToDecimal(mantissa, negative, (byte)decScale);
+            }
+        }
+
+        private static decimal UInt128ToDecimal(UInt128 value, bool negative, byte scale)
+        {
+            ulong lo64 = (ulong)(value & ulong.MaxValue);
+            uint hi32 = (uint)(value >> 64);
+            return new decimal((int)lo64, (int)(lo64 >> 32), (int)hi32, negative, scale);
+        }
+#endif
+
+        private static decimal GetDecimalViaBigInteger(ReadOnlySpan<byte> value, int scale)
+        {
             BigInteger integerValue;
 
 #if NETCOREAPP
@@ -61,12 +171,7 @@ namespace Apache.Arrow
                 {
                     throw new OverflowException($"Value: {integerPart} of {integerValue} is too small be represented as a decimal");
                 }
-                else if (fractionalPart > _maxDecimal || fractionalPart < _minDecimal)
-                {
-                    throw new OverflowException($"Value: {fractionalPart} of {integerValue} is too precise be represented as a decimal");
-                }
-
-                return (decimal)integerPart + DivideByScale(fractionalPart, scale);
+                return (decimal)integerPart + FractionToDecimal(fractionalPart, scale);
             }
             else
             {
@@ -203,6 +308,21 @@ namespace Apache.Arrow
 
                 return new SqlDecimal((byte)precision, (byte)scale, false, (int)(data1 & 0xffffffff), (int)(data1 >> 32), (int)(data2 & 0xffffffff), (int)(data2 >> 32));
             }
+        }
+
+        private static decimal FractionToDecimal(BigInteger fractionalPart, int scale)
+        {
+            // The fractional BigInteger may have more digits than decimal can represent (~28-29).
+            // Reduce it by dividing out powers of 10, losing the least-significant digits,
+            // then divide the remainder by the reduced scale.
+            int digitsRemoved = 0;
+            while (fractionalPart > _maxDecimal || fractionalPart < _minDecimal)
+            {
+                fractionalPart /= 10;
+                digitsRemoved++;
+            }
+
+            return DivideByScale(fractionalPart, scale - digitsRemoved);
         }
 
         private static decimal DivideByScale(BigInteger integerValue, int scale)

--- a/src/Apache.Arrow/DecimalUtility.cs
+++ b/src/Apache.Arrow/DecimalUtility.cs
@@ -56,6 +56,15 @@ namespace Apache.Arrow
 
         internal static decimal GetDecimal(in ArrowBuffer valueBuffer, int index, int scale, int byteWidth)
         {
+            if (!TryGetDecimal(valueBuffer, index, scale, byteWidth, out decimal result))
+            {
+                throw new OverflowException("Value is too large or too small to be represented as a decimal");
+            }
+            return result;
+        }
+
+        internal static bool TryGetDecimal(in ArrowBuffer valueBuffer, int index, int scale, int byteWidth, out decimal result)
+        {
             int startIndex = index * byteWidth;
             ReadOnlySpan<byte> value = valueBuffer.Span.Slice(startIndex, byteWidth);
 
@@ -63,7 +72,7 @@ namespace Apache.Arrow
             if (byteWidth == 16)
             {
                 Int128 int128Value = BinaryPrimitives.ReadInt128LittleEndian(value);
-                return GetDecimalViaInt128(int128Value, scale);
+                return TryGetDecimalViaInt128(int128Value, scale, out result);
             }
 
             if (byteWidth == 32)
@@ -74,16 +83,16 @@ namespace Apache.Arrow
                 Int128 signExtension = lower < 0 ? Int128.NegativeOne : Int128.Zero;
                 if (upper == signExtension)
                 {
-                    return GetDecimalViaInt128(lower, scale);
+                    return TryGetDecimalViaInt128(lower, scale, out result);
                 }
             }
 #endif
 
-            return GetDecimalViaBigInteger(value, scale);
+            return TryGetDecimalViaBigInteger(value, scale, out result);
         }
 
 #if NET7_0_OR_GREATER
-        private static decimal GetDecimalViaInt128(Int128 integerValue, int scale)
+        private static bool TryGetDecimalViaInt128(Int128 integerValue, int scale, out decimal result)
         {
             bool negative = integerValue < 0;
             UInt128 abs = negative ? (UInt128)(-integerValue) : (UInt128)integerValue;
@@ -91,12 +100,14 @@ namespace Apache.Arrow
             // Fast path: value fits directly in decimal (96-bit mantissa, scale <= 28)
             if (abs <= s_maxDecimalMantissa && scale <= 28)
             {
-                return UInt128ToDecimal(abs, negative, (byte)scale);
+                result = UInt128ToDecimal(abs, negative, (byte)scale);
+                return true;
             }
 
             if (scale == 0)
             {
-                throw new OverflowException($"Value: {integerValue} is too large to be represented as a decimal");
+                result = default;
+                return false;
             }
 
             // Split into integer and fractional parts
@@ -107,7 +118,8 @@ namespace Apache.Arrow
 
                 if (intPart > s_maxDecimalMantissa)
                 {
-                    throw new OverflowException($"Value is too large to be represented as a decimal");
+                    result = default;
+                    return false;
                 }
 
                 decimal intDecimal = UInt128ToDecimal(intPart, negative, 0);
@@ -121,7 +133,8 @@ namespace Apache.Arrow
                 }
 
                 decimal fracDecimal = UInt128ToDecimal(fracPart, false, (byte)fracScale);
-                return negative ? intDecimal - fracDecimal : intDecimal + fracDecimal;
+                result = negative ? intDecimal - fracDecimal : intDecimal + fracDecimal;
+                return true;
             }
             else
             {
@@ -135,7 +148,8 @@ namespace Apache.Arrow
                     decScale--;
                 }
 
-                return UInt128ToDecimal(mantissa, negative, (byte)decScale);
+                result = UInt128ToDecimal(mantissa, negative, (byte)decScale);
+                return true;
             }
         }
 
@@ -147,7 +161,7 @@ namespace Apache.Arrow
         }
 #endif
 
-        private static decimal GetDecimalViaBigInteger(ReadOnlySpan<byte> value, int scale)
+        private static bool TryGetDecimalViaBigInteger(ReadOnlySpan<byte> value, int scale, out decimal result)
         {
             BigInteger integerValue;
 
@@ -162,20 +176,19 @@ namespace Apache.Arrow
                 BigInteger scaleBy = BigInteger.Pow(10, scale);
                 BigInteger integerPart = BigInteger.DivRem(integerValue, scaleBy, out BigInteger fractionalPart);
 
-                // decimal overflow, not much we can do here - C# needs a BigDecimal
-                if (integerPart > _maxDecimal)
+                if (integerPart > _maxDecimal || integerPart < _minDecimal)
                 {
-                    throw new OverflowException($"Value: {integerPart} of {integerValue} is too big be represented as a decimal");
+                    result = default;
+                    return false;
                 }
-                else if (integerPart < _minDecimal)
-                {
-                    throw new OverflowException($"Value: {integerPart} of {integerValue} is too small be represented as a decimal");
-                }
-                return (decimal)integerPart + FractionToDecimal(fractionalPart, scale);
+
+                result = (decimal)integerPart + FractionToDecimal(fractionalPart, scale);
+                return true;
             }
             else
             {
-                return DivideByScale(integerValue, scale);
+                result = DivideByScale(integerValue, scale);
+                return true;
             }
         }
 

--- a/test/Apache.Arrow.Benchmarks/DecimalArrayBenchmark.cs
+++ b/test/Apache.Arrow.Benchmarks/DecimalArrayBenchmark.cs
@@ -1,0 +1,131 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Data.SqlTypes;
+using Apache.Arrow.Types;
+using BenchmarkDotNet.Attributes;
+
+namespace Apache.Arrow.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class DecimalArrayBenchmark
+    {
+        [Params(10_000)]
+        public int Count { get; set; }
+
+        private Decimal128Array _decimal128LowScale;
+        private Decimal128Array _decimal128HighScale;
+        private Decimal256Array _decimal256LowScale;
+        private Decimal256Array _decimal256HighScale;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            var random = new Random(42);
+
+            _decimal128LowScale = BuildDecimal128Array(new Decimal128Type(14, 4), random);
+            _decimal128HighScale = BuildDecimal128Array(new Decimal128Type(38, 20), random);
+            _decimal256LowScale = BuildDecimal256Array(new Decimal256Type(14, 4), random);
+            _decimal256HighScale = BuildDecimal256Array(new Decimal256Type(76, 38), random);
+        }
+
+        private Decimal128Array BuildDecimal128Array(Decimal128Type type, Random random)
+        {
+            var builder = new Decimal128Array.Builder(type);
+            for (int i = 0; i < Count; i++)
+            {
+                builder.Append((decimal)Math.Round(random.NextDouble() * 10000, Math.Min(type.Scale, 10)));
+            }
+            return builder.Build();
+        }
+
+        private Decimal256Array BuildDecimal256Array(Decimal256Type type, Random random)
+        {
+            var builder = new Decimal256Array.Builder(type);
+            for (int i = 0; i < Count; i++)
+            {
+                builder.Append((decimal)Math.Round(random.NextDouble() * 10000, Math.Min(type.Scale, 10)));
+            }
+            return builder.Build();
+        }
+
+        [Benchmark]
+        public decimal? Decimal128_GetValue_LowScale()
+        {
+            decimal? sum = 0;
+            for (int i = 0; i < _decimal128LowScale.Length; i++)
+            {
+                sum += _decimal128LowScale.GetValue(i);
+            }
+            return sum;
+        }
+
+        [Benchmark]
+        public decimal? Decimal128_GetValue_HighScale()
+        {
+            decimal? sum = 0;
+            for (int i = 0; i < _decimal128HighScale.Length; i++)
+            {
+                sum += _decimal128HighScale.GetValue(i);
+            }
+            return sum;
+        }
+
+        [Benchmark]
+        public decimal? Decimal256_GetValue_LowScale()
+        {
+            decimal? sum = 0;
+            for (int i = 0; i < _decimal256LowScale.Length; i++)
+            {
+                sum += _decimal256LowScale.GetValue(i);
+            }
+            return sum;
+        }
+
+        [Benchmark]
+        public decimal? Decimal256_GetValue_HighScale()
+        {
+            decimal? sum = 0;
+            for (int i = 0; i < _decimal256HighScale.Length; i++)
+            {
+                sum += _decimal256HighScale.GetValue(i);
+            }
+            return sum;
+        }
+
+        [Benchmark]
+        public SqlDecimal? Decimal128_GetSqlDecimal()
+        {
+            SqlDecimal? sum = 0;
+            for (int i = 0; i < _decimal128LowScale.Length; i++)
+            {
+                sum += _decimal128LowScale.GetSqlDecimal(i);
+            }
+            return sum;
+        }
+
+        [Benchmark]
+        public string Decimal256_GetString_HighScale()
+        {
+            string last = null;
+            for (int i = 0; i < _decimal256HighScale.Length; i++)
+            {
+                last = _decimal256HighScale.GetString(i);
+            }
+            return last;
+        }
+    }
+}

--- a/test/Apache.Arrow.Tests/Decimal128ArrayTests.cs
+++ b/test/Apache.Arrow.Tests/Decimal128ArrayTests.cs
@@ -504,6 +504,27 @@ namespace Apache.Arrow.Tests
             }
 
             [Fact]
+            public void TryGetValueReturnsFalse()
+            {
+                var array = new Decimal128Array.Builder(new Decimal128Type(38, 4))
+                    .Append(SqlDecimal.Parse("100000000000000000000000000000000"))
+                    .Build();
+
+                Assert.False(array.TryGetValue(0, out decimal? value));
+            }
+
+            [Fact]
+            public void TryGetValueCanRound()
+            {
+                var array = new Decimal128Array.Builder(new Decimal128Type(38, 8))
+                    .Append(SqlDecimal.Parse("10000000000000000000000000000.99"))
+                    .Build();
+
+                Assert.True(array.TryGetValue(0, out decimal? value));
+                Assert.Equal(10000000000000000000000000001m, value);
+            }
+
+            [Fact]
             public void TryGetValueNullReturnsTrue()
             {
                 var array = new Decimal128Array.Builder(new Decimal128Type(38, 20))

--- a/test/Apache.Arrow.Tests/Decimal128ArrayTests.cs
+++ b/test/Apache.Arrow.Tests/Decimal128ArrayTests.cs
@@ -459,6 +459,62 @@ namespace Apache.Arrow.Tests
             }
         }
 
+        public class HighPrecisionGetValue
+        {
+            [Fact]
+            public void GetValueWithHighScale()
+            {
+                // Decimal128 supports up to precision 38, scale 38
+                var array = new Decimal128Array.Builder(new Decimal128Type(38, 20))
+                    .Append(2422.85527600000m)
+                    .Build();
+
+                Assert.Equal(2422.85527600000m, array.GetValue(0));
+            }
+
+            [Fact]
+            public void GetValueWithMaxScaleFractionalOnly()
+            {
+                var array = new Decimal128Array.Builder(new Decimal128Type(38, 30))
+                    .Append(0.12345678m)
+                    .Build();
+
+                Assert.Equal(0.12345678m, array.GetValue(0));
+            }
+
+            [Fact]
+            public void GetValueWithHighScaleNegative()
+            {
+                var array = new Decimal128Array.Builder(new Decimal128Type(38, 20))
+                    .Append(-2422.85527600000m)
+                    .Build();
+
+                Assert.Equal(-2422.85527600000m, array.GetValue(0));
+            }
+
+            [Fact]
+            public void TryGetValueReturnsTrue()
+            {
+                var array = new Decimal128Array.Builder(new Decimal128Type(38, 20))
+                    .Append(2422.85527600000m)
+                    .Build();
+
+                Assert.True(array.TryGetValue(0, out decimal? value));
+                Assert.Equal(2422.85527600000m, value);
+            }
+
+            [Fact]
+            public void TryGetValueNullReturnsTrue()
+            {
+                var array = new Decimal128Array.Builder(new Decimal128Type(38, 20))
+                    .AppendNull()
+                    .Build();
+
+                Assert.True(array.TryGetValue(0, out decimal? value));
+                Assert.Null(value);
+            }
+        }
+
         [Fact]
         public void SliceDecimal128Array()
         {

--- a/test/Apache.Arrow.Tests/Decimal256ArrayTests.cs
+++ b/test/Apache.Arrow.Tests/Decimal256ArrayTests.cs
@@ -477,6 +477,82 @@ namespace Apache.Arrow.Tests
             }
         }
 
+        public class HighPrecisionGetValue
+        {
+            [Fact]
+            public void GetValueWithHighPrecisionAndScale()
+            {
+                // Exact scenario from https://github.com/apache/arrow-dotnet/issues/247
+                var array = new Decimal256Array.Builder(new Decimal256Type(76, 38))
+                    .Append(2422.85527600000m)
+                    .Build();
+
+                Assert.Equal(2422.85527600000m, array.GetValue(0));
+            }
+
+            [Fact]
+            public void GetValueWithHighScaleFractionalOnly()
+            {
+                var array = new Decimal256Array.Builder(new Decimal256Type(76, 38))
+                    .Append(0.12345678901234567890m)
+                    .Build();
+
+                Assert.Equal(0.12345678901234567890m, array.GetValue(0));
+            }
+
+            [Fact]
+            public void GetValueWithHighScaleNegative()
+            {
+                var array = new Decimal256Array.Builder(new Decimal256Type(76, 38))
+                    .Append(-2422.85527600000m)
+                    .Build();
+
+                Assert.Equal(-2422.85527600000m, array.GetValue(0));
+            }
+
+            [Fact]
+            public void GetValueWithHighScaleZero()
+            {
+                var array = new Decimal256Array.Builder(new Decimal256Type(76, 38))
+                    .Append(0m)
+                    .Build();
+
+                Assert.Equal(0m, array.GetValue(0));
+            }
+
+            [Fact]
+            public void GetValueWithHighScaleWholeNumber()
+            {
+                var array = new Decimal256Array.Builder(new Decimal256Type(76, 38))
+                    .Append(12345m)
+                    .Build();
+
+                Assert.Equal(12345m, array.GetValue(0));
+            }
+
+            [Fact]
+            public void TryGetValueReturnsTrue()
+            {
+                var array = new Decimal256Array.Builder(new Decimal256Type(76, 38))
+                    .Append(2422.85527600000m)
+                    .Build();
+
+                Assert.True(array.TryGetValue(0, out decimal? value));
+                Assert.Equal(2422.85527600000m, value);
+            }
+
+            [Fact]
+            public void TryGetValueNullReturnsTrue()
+            {
+                var array = new Decimal256Array.Builder(new Decimal256Type(76, 38))
+                    .AppendNull()
+                    .Build();
+
+                Assert.True(array.TryGetValue(0, out decimal? value));
+                Assert.Null(value);
+            }
+        }
+
         [Fact]
         public void SliceDecimal256Array()
         {

--- a/test/Apache.Arrow.Tests/Decimal256ArrayTests.cs
+++ b/test/Apache.Arrow.Tests/Decimal256ArrayTests.cs
@@ -542,6 +542,27 @@ namespace Apache.Arrow.Tests
             }
 
             [Fact]
+            public void TryGetValueReturnsFalse()
+            {
+                var array = new Decimal256Array.Builder(new Decimal256Type(38, 4))
+                    .Append(SqlDecimal.Parse("100000000000000000000000000000000"))
+                    .Build();
+
+                Assert.False(array.TryGetValue(0, out decimal? value));
+            }
+
+            [Fact]
+            public void TryGetValueCanRound()
+            {
+                var array = new Decimal256Array.Builder(new Decimal256Type(38, 8))
+                    .Append(SqlDecimal.Parse("10000000000000000000000000000.99"))
+                    .Build();
+
+                Assert.True(array.TryGetValue(0, out decimal? value));
+                Assert.Equal(10000000000000000000000000001m, value);
+            }
+
+            [Fact]
             public void TryGetValueNullReturnsTrue()
             {
                 var array = new Decimal256Array.Builder(new Decimal256Type(76, 38))

--- a/test/Apache.Arrow.Tests/DecimalUtilityTests.cs
+++ b/test/Apache.Arrow.Tests/DecimalUtilityTests.cs
@@ -50,7 +50,7 @@ namespace Apache.Arrow.Tests
 
             [Theory]
             [InlineData(4.56, 38, 9, false)]
-            [InlineData(7.89, 76, 38, true)]
+            [InlineData(7.89, 76, 38, false)]
             public void Decimal256HasExpectedResultOrThrows(decimal d, int precision, int scale, bool shouldThrow)
             {
                 var builder = new Decimal256Array.Builder(new Decimal256Type(precision, scale));


### PR DESCRIPTION
## What's Changed

  - Fixes DecimalUtility.GetDecimal to correctly handle high-scale values (e.g., Decimal256 with precision 76, scale 38) that previously threw OverflowException — addresses issue #247
  - Adds a fast path using Int128 on .NET 7+ that avoids BigInteger allocation for values that fit in 128 bits
  - Replaces the old fractional-part overflow check (which threw) with FractionToDecimal, which gracefully reduces precision to fit within decimal's ~28-digit mantissa

Closes #247.
Partially addresses #96.
