### PR TITLE
perf: reduce ArrowBuffer builder reallocation work

### DIFF
--- a/src/Apache.Arrow/ArrowBuffer.Builder.cs
+++ b/src/Apache.Arrow/ArrowBuffer.Builder.cs
@@ -132,6 +132,15 @@ namespace Apache.Arrow
             {
                 if (values != null)
                 {
+                    if (values is ICollection<T> collection)
+                    {
+                        EnsureAdditionalCapacity(collection.Count);
+                    }
+                    else if (values is IReadOnlyCollection<T> readOnlyCollection)
+                    {
+                        EnsureAdditionalCapacity(readOnlyCollection.Count);
+                    }
+
                     foreach (T v in values)
                     {
                         Append(v);
@@ -243,7 +252,7 @@ namespace Apache.Arrow
                 if (numBytes != 0)
                 {
                     var memory = new Memory<byte>(new byte[numBytes]);
-                    Memory.CopyTo(memory);
+                    Memory.Slice(0, Length * _size).CopyTo(memory);
 
                     Memory = memory;
                 }

--- a/test/Apache.Arrow.Tests/ArrowBufferBuilderTests.cs
+++ b/test/Apache.Arrow.Tests/ArrowBufferBuilderTests.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -158,6 +160,65 @@ namespace Apache.Arrow.Tests
                     Assert.Equal(i, span[i]);
                 }
             }
+
+            [Fact]
+            public void BufferHasExpectedValuesForRangeEnumerable()
+            {
+                var builder = new ArrowBuffer.Builder<int>(1);
+
+                builder.AppendRange(Enumerable.Range(0, 10));
+
+                var buffer = builder.Build();
+                var span = buffer.Span.CastTo<int>();
+
+                for (var i = 0; i < 10; i++)
+                {
+                    Assert.Equal(i, span[i]);
+                }
+            }
+
+            [Fact]
+            public void BufferHasExpectedValuesForReadOnlyCollection()
+            {
+                var builder = new ArrowBuffer.Builder<int>(1);
+                var data = new CountingReadOnlyCollection(Enumerable.Range(0, 10).ToArray());
+
+                builder.AppendRange(data);
+
+                var buffer = builder.Build();
+                var span = buffer.Span.CastTo<int>();
+
+                Assert.Equal(1, data.CountAccesses);
+                for (var i = 0; i < 10; i++)
+                {
+                    Assert.Equal(i, span[i]);
+                }
+            }
+
+            private sealed class CountingReadOnlyCollection : IReadOnlyCollection<int>
+            {
+                private readonly int[] _values;
+
+                public CountingReadOnlyCollection(int[] values)
+                {
+                    _values = values;
+                }
+
+                public int CountAccesses { get; private set; }
+
+                public int Count
+                {
+                    get
+                    {
+                        CountAccesses++;
+                        return _values.Length;
+                    }
+                }
+
+                public IEnumerator<int> GetEnumerator() => ((IEnumerable<int>)_values).GetEnumerator();
+
+                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+            }
         }
 
         public class Clear
@@ -209,6 +270,19 @@ namespace Apache.Arrow.Tests
 
                 // Act/Assert
                 Assert.Throws<ArgumentOutOfRangeException>(() => builder.Resize(-1));
+            }
+
+            [Fact]
+            public void ReservePreservesAppendedValuesAfterReallocate()
+            {
+                var builder = new ArrowBuffer.Builder<int>(1);
+                builder.Append(42);
+
+                builder.Reserve(builder.Capacity + 1);
+
+                var buffer = builder.Build();
+                var span = buffer.Span.CastTo<int>();
+                Assert.Equal(42, span[0]);
             }
         }
 


### PR DESCRIPTION
## Summary

- Pre-reserve `ArrowBuffer.Builder<T>` capacity when `AppendRange` receives a known-count collection.
- Copy only the populated `Length * sizeof(T)` portion when reallocating builder storage.
- Add focused coverage for enumerable, read-only collection, and reallocation preservation paths.

The reallocation behavior preserves appended/current-length contents. Capacity beyond `Length` remains undefined and is not copied across reallocations.

## Validation

- `dotnet test test/Apache.Arrow.Tests/Apache.Arrow.Tests.csproj -c Release --filter "FullyQualifiedName~Apache.Arrow.Tests.ArrowBufferBuilderTests"`
- `rtk dotnet build "Apache.Arrow.sln" -c Release`
- LSP diagnostics clean on changed files
- Code review completed before commit; no blockers found