### PR TITLE
perf: speed up MemoryStream IPC stream reads

### DIFF
--- a/src/Apache.Arrow/Ipc/ArrowMemoryReaderImplementation.cs
+++ b/src/Apache.Arrow/Ipc/ArrowMemoryReaderImplementation.cs
@@ -87,7 +87,7 @@ namespace Apache.Arrow.Ipc
                 else if (messageLength == MessageSerializer.IpcContinuationToken)
                 {
                     // ARROW-6313, if the first 4 bytes are continuation message, read the next 4 for the length
-                    if (_buffer.Length <= _bufferPosition + sizeof(int))
+                    if (_buffer.Length < _bufferPosition + sizeof(int))
                     {
                         throw new InvalidDataException("Corrupted IPC message. Received a continuation token at the end of the message.");
                     }
@@ -136,7 +136,7 @@ namespace Apache.Arrow.Ipc
             if (schemaMessageLength == MessageSerializer.IpcContinuationToken)
             {
                 // ARROW-6313, if the first 4 bytes are continuation message, read the next 4 for the length
-                if (_buffer.Length <= _bufferPosition + sizeof(int))
+                if (_buffer.Length < _bufferPosition + sizeof(int))
                 {
                     throw new InvalidDataException("Corrupted IPC message. Received a continuation token at the end of the message.");
                 }

--- a/src/Apache.Arrow/Ipc/ArrowMemoryStreamReaderImplementation.cs
+++ b/src/Apache.Arrow/Ipc/ArrowMemoryStreamReaderImplementation.cs
@@ -32,6 +32,7 @@ namespace Apache.Arrow.Ipc
     internal sealed class ArrowMemoryStreamReaderImplementation : ArrowStreamReaderImplementation
     {
         private readonly MemoryStream _stream;
+        private readonly Memory<byte> _streamMemory;
 
         public ArrowMemoryStreamReaderImplementation(
             MemoryStream stream,
@@ -42,6 +43,13 @@ namespace Apache.Arrow.Ipc
             : base(stream, allocator, compressionCodecFactory, leaveOpen, extensionRegistry)
         {
             _stream = stream;
+
+            if (!stream.TryGetBuffer(out ArraySegment<byte> streamBuffer))
+            {
+                throw new InvalidOperationException("Expected MemoryStream to expose its backing buffer.");
+            }
+
+            _streamMemory = streamBuffer.Array.AsMemory(streamBuffer.Offset, streamBuffer.Count);
         }
 
         public override ValueTask<RecordBatch> ReadNextRecordBatchAsync(CancellationToken cancellationToken)
@@ -65,7 +73,7 @@ namespace Apache.Arrow.Ipc
             ReadResult result = default;
             do
             {
-                result = ReadMessageFromExposedMemoryStream();
+                result = ReadMessageFromMemory();
             } while (result.Batch == null && result.MessageLength > 0);
 
             return result.Batch;
@@ -98,25 +106,25 @@ namespace Apache.Arrow.Ipc
                 return;
             }
 
-            int schemaMessageLength = ReadMessageLengthFromExposedMemoryStream(throwOnFullRead: true, returnOnEmptyStream: true);
+            int schemaMessageLength = ReadMessageLengthFromMemory(throwOnFullRead: true, returnOnEmptyStream: true);
             if (schemaMessageLength == 0)
             {
                 return;
             }
 
-            Memory<byte> schemaBuffer = ReadExposedMemory(schemaMessageLength);
+            Memory<byte> schemaBuffer = ReadMemory(schemaMessageLength);
             _schema = MessageSerializer.GetSchema(ReadMessage<Flatbuf.Schema>(CreateByteBuffer(schemaBuffer)), ref _dictionaryMemo, _extensionRegistry);
         }
 
-        private ReadResult ReadMessageFromExposedMemoryStream()
+        private ReadResult ReadMessageFromMemory()
         {
-            int messageLength = ReadMessageLengthFromExposedMemoryStream(throwOnFullRead: false, returnOnEmptyStream: false);
+            int messageLength = ReadMessageLengthFromMemory(throwOnFullRead: false, returnOnEmptyStream: false);
             if (messageLength == 0)
             {
                 return default;
             }
 
-            Memory<byte> messageBuffer = ReadExposedMemory(messageLength);
+            Memory<byte> messageBuffer = ReadMemory(messageLength);
             Flatbuf.Message message = Flatbuf.Message.GetRootAsMessage(CreateByteBuffer(messageBuffer));
 
             if (message.BodyLength > int.MaxValue)
@@ -127,7 +135,7 @@ namespace Apache.Arrow.Ipc
             }
 
             int bodyLength = (int)message.BodyLength;
-            Memory<byte> sourceBodyBuffer = ReadExposedMemory(bodyLength);
+            Memory<byte> sourceBodyBuffer = ReadMemory(bodyLength);
             IMemoryOwner<byte> bodyBufferOwner = AllocateMessageBodyBuffer(bodyLength);
             Memory<byte> bodyBuffer = bodyBufferOwner.Memory.Slice(0, bodyLength);
             sourceBodyBuffer.CopyTo(bodyBuffer);
@@ -137,20 +145,20 @@ namespace Apache.Arrow.Ipc
             return new ReadResult(messageLength, CreateArrowObjectFromMessage(message, bodybb, bodyBufferOwner));
         }
 
-        private int ReadMessageLengthFromExposedMemoryStream(bool throwOnFullRead, bool returnOnEmptyStream)
+        private int ReadMessageLengthFromMemory(bool throwOnFullRead, bool returnOnEmptyStream)
         {
             if (_stream.Position == _stream.Length && returnOnEmptyStream)
             {
                 return 0;
             }
 
-            if (!TryReadInt32FromExposedMemoryStream(throwOnFullRead, out int messageLength))
+            if (!TryReadInt32(throwOnFullRead, out int messageLength))
             {
                 return 0;
             }
 
             if (messageLength == MessageSerializer.IpcContinuationToken &&
-                !TryReadInt32FromExposedMemoryStream(throwOnFullRead, out messageLength))
+                !TryReadInt32(throwOnFullRead, out messageLength))
             {
                 return 0;
             }
@@ -158,11 +166,11 @@ namespace Apache.Arrow.Ipc
             return messageLength;
         }
 
-        private bool TryReadInt32FromExposedMemoryStream(bool throwOnFullRead, out int value)
+        private bool TryReadInt32(bool throwOnFullRead, out int value)
         {
             value = 0;
 
-            if (!TryReadExposedMemory(sizeof(int), throwOnFullRead, out Memory<byte> buffer))
+            if (!TryReadMemory(sizeof(int), throwOnFullRead, out Memory<byte> buffer))
             {
                 return false;
             }
@@ -171,7 +179,7 @@ namespace Apache.Arrow.Ipc
             return true;
         }
 
-        private bool TryReadExposedMemory(int length, bool throwOnFullRead, out Memory<byte> buffer)
+        private bool TryReadMemory(int length, bool throwOnFullRead, out Memory<byte> buffer)
         {
             buffer = default;
 
@@ -187,24 +195,18 @@ namespace Apache.Arrow.Ipc
                 return false;
             }
 
-            buffer = ReadExposedMemory(length);
+            buffer = ReadMemory(length);
             return true;
         }
 
-        private Memory<byte> ReadExposedMemory(int length)
+        private Memory<byte> ReadMemory(int length)
         {
             if (length == 0)
             {
                 return Memory<byte>.Empty;
             }
 
-            if (!_stream.TryGetBuffer(out ArraySegment<byte> streamBuffer))
-            {
-                throw new InvalidOperationException("Expected MemoryStream to expose its backing buffer.");
-            }
-
-            int offset = checked(streamBuffer.Offset + (int)_stream.Position);
-            Memory<byte> buffer = streamBuffer.Array.AsMemory(offset, length);
+            Memory<byte> buffer = _streamMemory.Slice(checked((int)_stream.Position), length);
             _stream.Position += length;
             return buffer;
         }

--- a/src/Apache.Arrow/Ipc/ArrowMemoryStreamReaderImplementation.cs
+++ b/src/Apache.Arrow/Ipc/ArrowMemoryStreamReaderImplementation.cs
@@ -1,0 +1,212 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Buffers;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Arrow.Memory;
+
+namespace Apache.Arrow.Ipc
+{
+    /// <summary>
+    /// Reads Arrow IPC streams from a <see cref="MemoryStream"/> whose backing buffer is publicly visible.
+    /// </summary>
+    /// <remarks>
+    /// Message metadata can be read directly from the exposed stream buffer, but record batch bodies are
+    /// still copied into allocator-owned buffers to preserve <see cref="ArrowStreamReader"/> ownership semantics.
+    /// </remarks>
+    internal sealed class ArrowMemoryStreamReaderImplementation : ArrowStreamReaderImplementation
+    {
+        private readonly MemoryStream _stream;
+
+        public ArrowMemoryStreamReaderImplementation(
+            MemoryStream stream,
+            MemoryAllocator allocator,
+            ICompressionCodecFactory compressionCodecFactory,
+            bool leaveOpen,
+            ExtensionTypeRegistry extensionRegistry)
+            : base(stream, allocator, compressionCodecFactory, leaveOpen, extensionRegistry)
+        {
+            _stream = stream;
+        }
+
+        public override ValueTask<RecordBatch> ReadNextRecordBatchAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                return new ValueTask<RecordBatch>(ReadNextRecordBatch());
+            }
+            catch (Exception ex)
+            {
+                return new ValueTask<RecordBatch>(Task.FromException<RecordBatch>(ex));
+            }
+        }
+
+        public override RecordBatch ReadNextRecordBatch()
+        {
+            ReadSchema();
+
+            ReadResult result = default;
+            do
+            {
+                result = ReadMessageFromExposedMemoryStream();
+            } while (result.Batch == null && result.MessageLength > 0);
+
+            return result.Batch;
+        }
+
+        public override ValueTask<Schema> ReadSchemaAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (HasReadSchema)
+            {
+                return new ValueTask<Schema>(_schema);
+            }
+
+            try
+            {
+                ReadSchema();
+                return new ValueTask<Schema>(_schema);
+            }
+            catch (Exception ex)
+            {
+                return new ValueTask<Schema>(Task.FromException<Schema>(ex));
+            }
+        }
+
+        public override void ReadSchema()
+        {
+            if (HasReadSchema)
+            {
+                return;
+            }
+
+            int schemaMessageLength = ReadMessageLengthFromExposedMemoryStream(throwOnFullRead: true, returnOnEmptyStream: true);
+            if (schemaMessageLength == 0)
+            {
+                return;
+            }
+
+            Memory<byte> schemaBuffer = ReadExposedMemory(schemaMessageLength);
+            _schema = MessageSerializer.GetSchema(ReadMessage<Flatbuf.Schema>(CreateByteBuffer(schemaBuffer)), ref _dictionaryMemo, _extensionRegistry);
+        }
+
+        private ReadResult ReadMessageFromExposedMemoryStream()
+        {
+            int messageLength = ReadMessageLengthFromExposedMemoryStream(throwOnFullRead: false, returnOnEmptyStream: false);
+            if (messageLength == 0)
+            {
+                return default;
+            }
+
+            Memory<byte> messageBuffer = ReadExposedMemory(messageLength);
+            Flatbuf.Message message = Flatbuf.Message.GetRootAsMessage(CreateByteBuffer(messageBuffer));
+
+            if (message.BodyLength > int.MaxValue)
+            {
+                throw new OverflowException(
+                    $"Arrow IPC message body length ({message.BodyLength}) is larger than " +
+                    $"the maximum supported message size ({int.MaxValue})");
+            }
+
+            int bodyLength = (int)message.BodyLength;
+            Memory<byte> sourceBodyBuffer = ReadExposedMemory(bodyLength);
+            IMemoryOwner<byte> bodyBufferOwner = AllocateMessageBodyBuffer(bodyLength);
+            Memory<byte> bodyBuffer = bodyBufferOwner.Memory.Slice(0, bodyLength);
+            sourceBodyBuffer.CopyTo(bodyBuffer);
+            Google.FlatBuffers.ByteBuffer bodybb = CreateByteBuffer(bodyBuffer);
+
+            // Keep stream-reader ownership semantics: batches outlive the source MemoryStream buffer.
+            return new ReadResult(messageLength, CreateArrowObjectFromMessage(message, bodybb, bodyBufferOwner));
+        }
+
+        private int ReadMessageLengthFromExposedMemoryStream(bool throwOnFullRead, bool returnOnEmptyStream)
+        {
+            if (_stream.Position == _stream.Length && returnOnEmptyStream)
+            {
+                return 0;
+            }
+
+            if (!TryReadInt32FromExposedMemoryStream(throwOnFullRead, out int messageLength))
+            {
+                return 0;
+            }
+
+            if (messageLength == MessageSerializer.IpcContinuationToken &&
+                !TryReadInt32FromExposedMemoryStream(throwOnFullRead, out messageLength))
+            {
+                return 0;
+            }
+
+            return messageLength;
+        }
+
+        private bool TryReadInt32FromExposedMemoryStream(bool throwOnFullRead, out int value)
+        {
+            value = 0;
+
+            if (!TryReadExposedMemory(sizeof(int), throwOnFullRead, out Memory<byte> buffer))
+            {
+                return false;
+            }
+
+            value = BitUtility.ReadInt32(buffer);
+            return true;
+        }
+
+        private bool TryReadExposedMemory(int length, bool throwOnFullRead, out Memory<byte> buffer)
+        {
+            buffer = default;
+
+            long remainingLength = _stream.Length - _stream.Position;
+            if (remainingLength < length)
+            {
+                if (throwOnFullRead)
+                {
+                    throw new InvalidOperationException("Unexpectedly reached the end of the stream before a full buffer was read.");
+                }
+
+                _stream.Position = _stream.Length;
+                return false;
+            }
+
+            buffer = ReadExposedMemory(length);
+            return true;
+        }
+
+        private Memory<byte> ReadExposedMemory(int length)
+        {
+            if (length == 0)
+            {
+                return Memory<byte>.Empty;
+            }
+
+            if (!_stream.TryGetBuffer(out ArraySegment<byte> streamBuffer))
+            {
+                throw new InvalidOperationException("Expected MemoryStream to expose its backing buffer.");
+            }
+
+            int offset = checked(streamBuffer.Offset + (int)_stream.Position);
+            Memory<byte> buffer = streamBuffer.Array.AsMemory(offset, length);
+            _stream.Position += length;
+            return buffer;
+        }
+    }
+}

--- a/src/Apache.Arrow/Ipc/ArrowStreamReader.cs
+++ b/src/Apache.Arrow/Ipc/ArrowStreamReader.cs
@@ -68,7 +68,7 @@ namespace Apache.Arrow.Ipc
             if (stream == null)
                 throw new ArgumentNullException(nameof(stream));
 
-            _implementation = new ArrowStreamReaderImplementation(stream, allocator, compressionCodecFactory, leaveOpen);
+            _implementation = CreateImplementation(stream, allocator, compressionCodecFactory, leaveOpen, extensionRegistry: null);
         }
 
         public ArrowStreamReader(ArrowContext context, Stream stream, bool leaveOpen = false)
@@ -78,7 +78,7 @@ namespace Apache.Arrow.Ipc
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
 
-            _implementation = new ArrowStreamReaderImplementation(stream, context.Allocator, context.CompressionCodecFactory, leaveOpen, context.ExtensionRegistry);
+            _implementation = CreateImplementation(stream, context.Allocator, context.CompressionCodecFactory, leaveOpen, context.ExtensionRegistry);
         }
 
         public ArrowStreamReader(ReadOnlyMemory<byte> buffer)
@@ -102,6 +102,21 @@ namespace Apache.Arrow.Ipc
         private protected ArrowStreamReader(ArrowReaderImplementation implementation)
         {
             _implementation = implementation;
+        }
+
+        private static ArrowReaderImplementation CreateImplementation(
+            Stream stream,
+            MemoryAllocator allocator,
+            ICompressionCodecFactory compressionCodecFactory,
+            bool leaveOpen,
+            ExtensionTypeRegistry extensionRegistry)
+        {
+            if (stream is MemoryStream memoryStream && memoryStream.TryGetBuffer(out _))
+            {
+                return new ArrowMemoryStreamReaderImplementation(memoryStream, allocator, compressionCodecFactory, leaveOpen, extensionRegistry);
+            }
+
+            return new ArrowStreamReaderImplementation(stream, allocator, compressionCodecFactory, leaveOpen, extensionRegistry);
         }
 
         public void Dispose()

--- a/src/Apache.Arrow/Ipc/ArrowStreamReaderImplementation.cs
+++ b/src/Apache.Arrow/Ipc/ArrowStreamReaderImplementation.cs
@@ -49,6 +49,7 @@ namespace Apache.Arrow.Ipc
 
         public override ValueTask<RecordBatch> ReadNextRecordBatchAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             return ReadRecordBatchAsync(cancellationToken);
         }
 

--- a/src/Apache.Arrow/Ipc/ArrowStreamReaderImplementation.cs
+++ b/src/Apache.Arrow/Ipc/ArrowStreamReaderImplementation.cs
@@ -49,20 +49,6 @@ namespace Apache.Arrow.Ipc
 
         public override ValueTask<RecordBatch> ReadNextRecordBatchAsync(CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            if (CanUseExposedMemoryStreamFastPath())
-            {
-                try
-                {
-                    return new ValueTask<RecordBatch>(ReadNextRecordBatch());
-                }
-                catch (Exception ex)
-                {
-                    return new ValueTask<RecordBatch>(Task.FromException<RecordBatch>(ex));
-                }
-            }
-
             return ReadRecordBatchAsync(cancellationToken);
         }
 
@@ -134,11 +120,6 @@ namespace Apache.Arrow.Ipc
 
         protected ReadResult ReadMessage()
         {
-            if (TryReadMessageFromExposedMemoryStream(out ReadResult directResult))
-            {
-                return directResult;
-            }
-
             int messageLength = ReadMessageLength(throwOnFullRead: false, returnOnEmptyStream: false);
             if (messageLength == 0)
             {
@@ -174,158 +155,9 @@ namespace Apache.Arrow.Ipc
             return new ReadResult(messageLength, result);
         }
 
-        private IMemoryOwner<byte> AllocateMessageBodyBuffer(int bodyLength)
+        protected IMemoryOwner<byte> AllocateMessageBodyBuffer(int bodyLength)
         {
             return _allocator.Allocate(bodyLength);
-        }
-
-        private bool TryReadMessageFromExposedMemoryStream(out ReadResult result)
-        {
-            result = default;
-
-            if (!TryReadMessageLengthFromExposedMemoryStream(throwOnFullRead: false, returnOnEmptyStream: false, out int messageLength))
-            {
-                return false;
-            }
-
-            if (messageLength == 0)
-            {
-                return true;
-            }
-
-            TryGetExposedMemoryStream(out MemoryStream stream, out ArraySegment<byte> streamBuffer);
-
-            Memory<byte> messageBuffer = ReadExposedMemory(stream, streamBuffer, messageLength);
-            Flatbuf.Message message = Flatbuf.Message.GetRootAsMessage(CreateByteBuffer(messageBuffer));
-
-            if (message.BodyLength > int.MaxValue)
-            {
-                throw new OverflowException(
-                    $"Arrow IPC message body length ({message.BodyLength}) is larger than " +
-                    $"the maximum supported message size ({int.MaxValue})");
-            }
-
-            int bodyLength = (int)message.BodyLength;
-            Memory<byte> sourceBodyBuffer = ReadExposedMemory(stream, streamBuffer, bodyLength);
-            IMemoryOwner<byte> bodyBufferOwner = AllocateMessageBodyBuffer(bodyLength);
-            Memory<byte> bodyBuffer = bodyBufferOwner.Memory.Slice(0, bodyLength);
-            sourceBodyBuffer.CopyTo(bodyBuffer);
-            Google.FlatBuffers.ByteBuffer bodybb = CreateByteBuffer(bodyBuffer);
-
-            // Stream readers have historically returned batches backed by reader-owned body
-            // buffers. Keep that ownership boundary even when the stream exposes its byte[].
-            result = new ReadResult(messageLength, CreateArrowObjectFromMessage(message, bodybb, bodyBufferOwner));
-            return true;
-        }
-
-        private bool TryReadSchemaFromExposedMemoryStream()
-        {
-            if (!TryReadMessageLengthFromExposedMemoryStream(throwOnFullRead: true, returnOnEmptyStream: true, out int schemaMessageLength))
-            {
-                return false;
-            }
-
-            if (schemaMessageLength == 0)
-            {
-                return true;
-            }
-
-            TryGetExposedMemoryStream(out MemoryStream stream, out ArraySegment<byte> streamBuffer);
-            Memory<byte> schemaBuffer = ReadExposedMemory(stream, streamBuffer, schemaMessageLength);
-            _schema = MessageSerializer.GetSchema(ReadMessage<Flatbuf.Schema>(CreateByteBuffer(schemaBuffer)), ref _dictionaryMemo, _extensionRegistry);
-            return true;
-        }
-
-        private bool TryReadMessageLengthFromExposedMemoryStream(bool throwOnFullRead, bool returnOnEmptyStream, out int messageLength)
-        {
-            messageLength = 0;
-
-            if (!TryGetExposedMemoryStream(out MemoryStream stream, out ArraySegment<byte> streamBuffer))
-            {
-                return false;
-            }
-
-            if (stream.Position == stream.Length && returnOnEmptyStream)
-            {
-                return true;
-            }
-
-            if (!TryReadInt32FromExposedMemoryStream(stream, streamBuffer, throwOnFullRead, out messageLength))
-            {
-                return true;
-            }
-
-            if (messageLength == MessageSerializer.IpcContinuationToken &&
-                !TryReadInt32FromExposedMemoryStream(stream, streamBuffer, throwOnFullRead, out messageLength))
-            {
-                return true;
-            }
-
-            return true;
-        }
-
-        private static bool TryReadInt32FromExposedMemoryStream(MemoryStream stream, ArraySegment<byte> streamBuffer, bool throwOnFullRead, out int value)
-        {
-            value = 0;
-
-            if (!TryReadExposedMemory(stream, streamBuffer, sizeof(int), throwOnFullRead, out Memory<byte> buffer))
-            {
-                return false;
-            }
-
-            value = BitUtility.ReadInt32(buffer);
-            return true;
-        }
-
-        private static bool TryReadExposedMemory(MemoryStream stream, ArraySegment<byte> streamBuffer, int length, bool throwOnFullRead, out Memory<byte> buffer)
-        {
-            buffer = default;
-
-            long remainingLength = stream.Length - stream.Position;
-            if (remainingLength < length)
-            {
-                if (throwOnFullRead)
-                {
-                    throw new InvalidOperationException("Unexpectedly reached the end of the stream before a full buffer was read.");
-                }
-
-                stream.Position = stream.Length;
-                return false;
-            }
-
-            buffer = ReadExposedMemory(stream, streamBuffer, length);
-            return true;
-        }
-
-        private static Memory<byte> ReadExposedMemory(MemoryStream stream, ArraySegment<byte> streamBuffer, int length)
-        {
-            if (length == 0)
-            {
-                return Memory<byte>.Empty;
-            }
-
-            int offset = checked(streamBuffer.Offset + (int)stream.Position);
-            Memory<byte> buffer = streamBuffer.Array.AsMemory(offset, length);
-            stream.Position += length;
-            return buffer;
-        }
-
-        private bool TryGetExposedMemoryStream(out MemoryStream stream, out ArraySegment<byte> streamBuffer)
-        {
-            if (BaseStream is MemoryStream memoryStream && memoryStream.TryGetBuffer(out streamBuffer))
-            {
-                stream = memoryStream;
-                return true;
-            }
-
-            stream = null;
-            streamBuffer = default;
-            return false;
-        }
-
-        protected bool CanUseExposedMemoryStreamFastPath()
-        {
-            return TryGetExposedMemoryStream(out _, out _);
         }
 
         public override ValueTask<Schema> ReadSchemaAsync(CancellationToken cancellationToken = default)
@@ -335,19 +167,6 @@ namespace Apache.Arrow.Ipc
             if (HasReadSchema)
             {
                 return new ValueTask<Schema>(_schema);
-            }
-
-            if (CanUseExposedMemoryStreamFastPath())
-            {
-                try
-                {
-                    ReadSchema();
-                    return new ValueTask<Schema>(_schema);
-                }
-                catch (Exception ex)
-                {
-                    return new ValueTask<Schema>(Task.FromException<Schema>(ex));
-                }
             }
 
             return ReadSchemaAsyncCore(cancellationToken);
@@ -378,11 +197,6 @@ namespace Apache.Arrow.Ipc
         public override void ReadSchema()
         {
             if (HasReadSchema)
-            {
-                return;
-            }
-
-            if (TryReadSchemaFromExposedMemoryStream())
             {
                 return;
             }
@@ -512,6 +326,5 @@ namespace Apache.Arrow.Ipc
                 Batch = batch;
             }
         }
-
     }
 }

--- a/src/Apache.Arrow/Ipc/ArrowStreamReaderImplementation.cs
+++ b/src/Apache.Arrow/Ipc/ArrowStreamReaderImplementation.cs
@@ -47,11 +47,23 @@ namespace Apache.Arrow.Ipc
             }
         }
 
-        public override async ValueTask<RecordBatch> ReadNextRecordBatchAsync(CancellationToken cancellationToken)
+        public override ValueTask<RecordBatch> ReadNextRecordBatchAsync(CancellationToken cancellationToken)
         {
-            // TODO: Loop until a record batch is read.
             cancellationToken.ThrowIfCancellationRequested();
-            return await ReadRecordBatchAsync(cancellationToken).ConfigureAwait(false);
+
+            if (CanUseExposedMemoryStreamFastPath())
+            {
+                try
+                {
+                    return new ValueTask<RecordBatch>(ReadNextRecordBatch());
+                }
+                catch (Exception ex)
+                {
+                    return new ValueTask<RecordBatch>(Task.FromException<RecordBatch>(ex));
+                }
+            }
+
+            return ReadRecordBatchAsync(cancellationToken);
         }
 
         public override RecordBatch ReadNextRecordBatch()
@@ -61,7 +73,7 @@ namespace Apache.Arrow.Ipc
 
         protected async ValueTask<RecordBatch> ReadRecordBatchAsync(CancellationToken cancellationToken = default)
         {
-            await ReadSchemaAsync().ConfigureAwait(false);
+            await ReadSchemaAsync(cancellationToken).ConfigureAwait(false);
 
             ReadResult result = default;
             do
@@ -94,7 +106,7 @@ namespace Apache.Arrow.Ipc
 
                 int bodyLength = checked((int)message.BodyLength);
 
-                IMemoryOwner<byte> bodyBuffOwner = _allocator.Allocate(bodyLength);
+                IMemoryOwner<byte> bodyBuffOwner = AllocateMessageBodyBuffer(bodyLength);
                 Memory<byte> bodyBuff = bodyBuffOwner.Memory.Slice(0, bodyLength);
                 bytesRead = await BaseStream.ReadFullBufferAsync(bodyBuff, cancellationToken)
                     .ConfigureAwait(false);
@@ -122,6 +134,11 @@ namespace Apache.Arrow.Ipc
 
         protected ReadResult ReadMessage()
         {
+            if (TryReadMessageFromExposedMemoryStream(out ReadResult directResult))
+            {
+                return directResult;
+            }
+
             int messageLength = ReadMessageLength(throwOnFullRead: false, returnOnEmptyStream: false);
             if (messageLength == 0)
             {
@@ -145,7 +162,7 @@ namespace Apache.Arrow.Ipc
                 }
                 int bodyLength = (int)message.BodyLength;
 
-                IMemoryOwner<byte> bodyBuffOwner = _allocator.Allocate(bodyLength);
+                IMemoryOwner<byte> bodyBuffOwner = AllocateMessageBodyBuffer(bodyLength);
                 Memory<byte> bodyBuff = bodyBuffOwner.Memory.Slice(0, bodyLength);
                 bytesRead = BaseStream.ReadFullBuffer(bodyBuff);
                 EnsureFullRead(bodyBuff, bytesRead);
@@ -157,13 +174,187 @@ namespace Apache.Arrow.Ipc
             return new ReadResult(messageLength, result);
         }
 
-        public override async ValueTask<Schema> ReadSchemaAsync(CancellationToken cancellationToken = default)
+        private IMemoryOwner<byte> AllocateMessageBodyBuffer(int bodyLength)
         {
-            if (HasReadSchema)
+            return _allocator.Allocate(bodyLength);
+        }
+
+        private bool TryReadMessageFromExposedMemoryStream(out ReadResult result)
+        {
+            result = default;
+
+            if (!TryReadMessageLengthFromExposedMemoryStream(throwOnFullRead: false, returnOnEmptyStream: false, out int messageLength))
             {
-                return _schema;
+                return false;
             }
 
+            if (messageLength == 0)
+            {
+                return true;
+            }
+
+            TryGetExposedMemoryStream(out MemoryStream stream, out ArraySegment<byte> streamBuffer);
+
+            Memory<byte> messageBuffer = ReadExposedMemory(stream, streamBuffer, messageLength);
+            Flatbuf.Message message = Flatbuf.Message.GetRootAsMessage(CreateByteBuffer(messageBuffer));
+
+            if (message.BodyLength > int.MaxValue)
+            {
+                throw new OverflowException(
+                    $"Arrow IPC message body length ({message.BodyLength}) is larger than " +
+                    $"the maximum supported message size ({int.MaxValue})");
+            }
+
+            int bodyLength = (int)message.BodyLength;
+            Memory<byte> sourceBodyBuffer = ReadExposedMemory(stream, streamBuffer, bodyLength);
+            IMemoryOwner<byte> bodyBufferOwner = AllocateMessageBodyBuffer(bodyLength);
+            Memory<byte> bodyBuffer = bodyBufferOwner.Memory.Slice(0, bodyLength);
+            sourceBodyBuffer.CopyTo(bodyBuffer);
+            Google.FlatBuffers.ByteBuffer bodybb = CreateByteBuffer(bodyBuffer);
+
+            // Stream readers have historically returned batches backed by reader-owned body
+            // buffers. Keep that ownership boundary even when the stream exposes its byte[].
+            result = new ReadResult(messageLength, CreateArrowObjectFromMessage(message, bodybb, bodyBufferOwner));
+            return true;
+        }
+
+        private bool TryReadSchemaFromExposedMemoryStream()
+        {
+            if (!TryReadMessageLengthFromExposedMemoryStream(throwOnFullRead: true, returnOnEmptyStream: true, out int schemaMessageLength))
+            {
+                return false;
+            }
+
+            if (schemaMessageLength == 0)
+            {
+                return true;
+            }
+
+            TryGetExposedMemoryStream(out MemoryStream stream, out ArraySegment<byte> streamBuffer);
+            Memory<byte> schemaBuffer = ReadExposedMemory(stream, streamBuffer, schemaMessageLength);
+            _schema = MessageSerializer.GetSchema(ReadMessage<Flatbuf.Schema>(CreateByteBuffer(schemaBuffer)), ref _dictionaryMemo, _extensionRegistry);
+            return true;
+        }
+
+        private bool TryReadMessageLengthFromExposedMemoryStream(bool throwOnFullRead, bool returnOnEmptyStream, out int messageLength)
+        {
+            messageLength = 0;
+
+            if (!TryGetExposedMemoryStream(out MemoryStream stream, out ArraySegment<byte> streamBuffer))
+            {
+                return false;
+            }
+
+            if (stream.Position == stream.Length && returnOnEmptyStream)
+            {
+                return true;
+            }
+
+            if (!TryReadInt32FromExposedMemoryStream(stream, streamBuffer, throwOnFullRead, out messageLength))
+            {
+                return true;
+            }
+
+            if (messageLength == MessageSerializer.IpcContinuationToken &&
+                !TryReadInt32FromExposedMemoryStream(stream, streamBuffer, throwOnFullRead, out messageLength))
+            {
+                return true;
+            }
+
+            return true;
+        }
+
+        private static bool TryReadInt32FromExposedMemoryStream(MemoryStream stream, ArraySegment<byte> streamBuffer, bool throwOnFullRead, out int value)
+        {
+            value = 0;
+
+            if (!TryReadExposedMemory(stream, streamBuffer, sizeof(int), throwOnFullRead, out Memory<byte> buffer))
+            {
+                return false;
+            }
+
+            value = BitUtility.ReadInt32(buffer);
+            return true;
+        }
+
+        private static bool TryReadExposedMemory(MemoryStream stream, ArraySegment<byte> streamBuffer, int length, bool throwOnFullRead, out Memory<byte> buffer)
+        {
+            buffer = default;
+
+            long remainingLength = stream.Length - stream.Position;
+            if (remainingLength < length)
+            {
+                if (throwOnFullRead)
+                {
+                    throw new InvalidOperationException("Unexpectedly reached the end of the stream before a full buffer was read.");
+                }
+
+                stream.Position = stream.Length;
+                return false;
+            }
+
+            buffer = ReadExposedMemory(stream, streamBuffer, length);
+            return true;
+        }
+
+        private static Memory<byte> ReadExposedMemory(MemoryStream stream, ArraySegment<byte> streamBuffer, int length)
+        {
+            if (length == 0)
+            {
+                return Memory<byte>.Empty;
+            }
+
+            int offset = checked(streamBuffer.Offset + (int)stream.Position);
+            Memory<byte> buffer = streamBuffer.Array.AsMemory(offset, length);
+            stream.Position += length;
+            return buffer;
+        }
+
+        private bool TryGetExposedMemoryStream(out MemoryStream stream, out ArraySegment<byte> streamBuffer)
+        {
+            if (BaseStream is MemoryStream memoryStream && memoryStream.TryGetBuffer(out streamBuffer))
+            {
+                stream = memoryStream;
+                return true;
+            }
+
+            stream = null;
+            streamBuffer = default;
+            return false;
+        }
+
+        protected bool CanUseExposedMemoryStreamFastPath()
+        {
+            return TryGetExposedMemoryStream(out _, out _);
+        }
+
+        public override ValueTask<Schema> ReadSchemaAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (HasReadSchema)
+            {
+                return new ValueTask<Schema>(_schema);
+            }
+
+            if (CanUseExposedMemoryStreamFastPath())
+            {
+                try
+                {
+                    ReadSchema();
+                    return new ValueTask<Schema>(_schema);
+                }
+                catch (Exception ex)
+                {
+                    return new ValueTask<Schema>(Task.FromException<Schema>(ex));
+                }
+            }
+
+            return ReadSchemaAsyncCore(cancellationToken);
+        }
+
+        private async ValueTask<Schema> ReadSchemaAsyncCore(CancellationToken cancellationToken)
+        {
             // Figure out length of schema
             int schemaMessageLength = await ReadMessageLengthAsync(throwOnFullRead: true, returnOnEmptyStream: true, cancellationToken)
                 .ConfigureAwait(false);
@@ -187,6 +378,11 @@ namespace Apache.Arrow.Ipc
         public override void ReadSchema()
         {
             if (HasReadSchema)
+            {
+                return;
+            }
+
+            if (TryReadSchemaFromExposedMemoryStream())
             {
                 return;
             }
@@ -316,5 +512,6 @@ namespace Apache.Arrow.Ipc
                 Batch = batch;
             }
         }
+
     }
 }

--- a/test/Apache.Arrow.Benchmarks/ArrowReaderBenchmark.cs
+++ b/test/Apache.Arrow.Benchmarks/ArrowReaderBenchmark.cs
@@ -14,8 +14,8 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Apache.Arrow.Ipc;
 using Apache.Arrow.Memory;
@@ -29,8 +29,11 @@ namespace Apache.Arrow.Benchmarks
     [MemoryDiagnoser]
     public class ArrowReaderBenchmark
     {
-        [Params(10_000, 1_000_000)]
+        [Params(10_000, 100_000)]
         public int Count { get; set; }
+
+        [Params(1, 5)]
+        public int ColumnSetCount { get; set; }
 
         private MemoryStream _memoryStream;
         private static readonly MemoryAllocator s_allocator = new TestMemoryAllocator();
@@ -38,7 +41,10 @@ namespace Apache.Arrow.Benchmarks
         [GlobalSetup]
         public async Task GlobalSetup()
         {
-            RecordBatch batch = TestData.CreateSampleRecordBatch(length: Count, createDictionaryArray: false);
+            RecordBatch batch = TestData.CreateSampleRecordBatch(
+                length: Count,
+                columnSetCount: ColumnSetCount,
+                excludedTypes: new HashSet<ArrowTypeId> { ArrowTypeId.Dictionary, ArrowTypeId.RunEndEncoded });
             _memoryStream = new MemoryStream();
 
             ArrowStreamWriter writer = new ArrowStreamWriter(_memoryStream, batch.Schema);
@@ -84,6 +90,73 @@ namespace Apache.Arrow.Benchmarks
         }
 
         [Benchmark]
+        public async Task<double> ArrowReaderWithMemoryStream_ExplicitDefaultAllocator()
+        {
+            double sum = 0;
+            var reader = new ArrowStreamReader(_memoryStream, MemoryAllocator.Default.Value);
+            RecordBatch recordBatch;
+            while ((recordBatch = await reader.ReadNextRecordBatchAsync()) != null)
+            {
+                using (recordBatch)
+                {
+                    sum += SumAllNumbers(recordBatch);
+                }
+            }
+            return sum;
+        }
+
+        [Benchmark]
+        public async Task<double> ArrowReaderWithNonPubliclyVisibleMemoryStream()
+        {
+            double sum = 0;
+            using var stream = CreateNonPubliclyVisibleReadStream();
+            using var reader = new ArrowStreamReader(stream);
+            RecordBatch recordBatch;
+            while ((recordBatch = await reader.ReadNextRecordBatchAsync()) != null)
+            {
+                using (recordBatch)
+                {
+                    sum += SumAllNumbers(recordBatch);
+                }
+            }
+            return sum;
+        }
+
+        [Benchmark]
+        public async Task<double> ArrowReaderWithNonPubliclyVisibleMemoryStream_ManagedMemory()
+        {
+            double sum = 0;
+            using var stream = CreateNonPubliclyVisibleReadStream();
+            using var reader = new ArrowStreamReader(stream, s_allocator);
+            RecordBatch recordBatch;
+            while ((recordBatch = await reader.ReadNextRecordBatchAsync()) != null)
+            {
+                using (recordBatch)
+                {
+                    sum += SumAllNumbers(recordBatch);
+                }
+            }
+            return sum;
+        }
+
+        [Benchmark]
+        public async Task<double> ArrowReaderWithNonPubliclyVisibleMemoryStream_ExplicitDefaultAllocator()
+        {
+            double sum = 0;
+            using var stream = CreateNonPubliclyVisibleReadStream();
+            using var reader = new ArrowStreamReader(stream, MemoryAllocator.Default.Value);
+            RecordBatch recordBatch;
+            while ((recordBatch = await reader.ReadNextRecordBatchAsync()) != null)
+            {
+                using (recordBatch)
+                {
+                    sum += SumAllNumbers(recordBatch);
+                }
+            }
+            return sum;
+        }
+
+        [Benchmark]
         public async Task<double> ArrowReaderWithMemory()
         {
             double sum = 0;
@@ -99,14 +172,25 @@ namespace Apache.Arrow.Benchmarks
             return sum;
         }
 
+        private MemoryStream CreateNonPubliclyVisibleReadStream()
+        {
+            return new MemoryStream(
+                _memoryStream.GetBuffer(),
+                index: 0,
+                count: checked((int)_memoryStream.Length),
+                writable: false,
+                publiclyVisible: false);
+        }
+
         private static double SumAllNumbers(RecordBatch recordBatch)
         {
             double sum = 0;
 
             for (int k = 0; k < recordBatch.ColumnCount; k++)
             {
-                var array = recordBatch.Arrays.ElementAt(k);
-                switch (recordBatch.Schema.GetFieldByIndex(k).DataType.TypeId)
+                var array = recordBatch.Column(k);
+                ArrowTypeId typeId = recordBatch.Schema.GetFieldByIndex(k).DataType.TypeId;
+                switch (typeId)
                 {
                     case ArrowTypeId.Int64:
                         Int64Array int64Array = (Int64Array)array;

--- a/test/Apache.Arrow.Benchmarks/ArrowReaderBenchmark.cs
+++ b/test/Apache.Arrow.Benchmarks/ArrowReaderBenchmark.cs
@@ -29,7 +29,7 @@ namespace Apache.Arrow.Benchmarks
     [MemoryDiagnoser]
     public class ArrowReaderBenchmark
     {
-        [Params(10_000, 100_000)]
+        [Params(10_000, 1_000_000)]
         public int Count { get; set; }
 
         [Params(1, 5)]

--- a/test/Apache.Arrow.Compression.Tests/ArrowStreamReaderTests.cs
+++ b/test/Apache.Arrow.Compression.Tests/ArrowStreamReaderTests.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using System;
+using System.IO;
 using System.Reflection;
 using Apache.Arrow.Ipc;
 using Apache.Arrow.Memory;
@@ -48,7 +49,7 @@ namespace Apache.Arrow.Compression.Tests
             using var stream = assembly.GetManifestResourceStream($"Apache.Arrow.Compression.Tests.Resources.{fileName}");
             Assert.NotNull(stream);
             var buffer = new byte[stream.Length];
-            stream.ReadExactly(buffer);
+            ReadExactly(stream, buffer);
             var codecFactory = new Compression.CompressionCodecFactory();
             using var reader = new ArrowStreamReader(buffer, codecFactory);
 
@@ -64,7 +65,7 @@ namespace Apache.Arrow.Compression.Tests
             using var stream = assembly.GetManifestResourceStream($"Apache.Arrow.Compression.Tests.Resources.{fileName}");
             Assert.NotNull(stream);
             var buffer = new byte[stream.Length];
-            stream.ReadExactly(buffer);
+            ReadExactly(stream, buffer);
             var codecFactory = new Compression.CompressionCodecFactory();
 
             long allocationsBeforeRead = MemoryAllocator.Default.Value.Statistics.Allocations;
@@ -106,6 +107,21 @@ namespace Apache.Arrow.Compression.Tests
             Assert.True(allocator.Statistics.Allocations > 0);
             Assert.Equal(0, allocator.Rented);
 
+        }
+
+        private static void ReadExactly(Stream stream, byte[] buffer)
+        {
+            int offset = 0;
+            while (offset < buffer.Length)
+            {
+                int bytesRead = stream.Read(buffer, offset, buffer.Length - offset);
+                if (bytesRead == 0)
+                {
+                    throw new EndOfStreamException();
+                }
+
+                offset += bytesRead;
+            }
         }
 
         private static void VerifyCompressedIpcFileBatch(RecordBatch batch)

--- a/test/Apache.Arrow.Compression.Tests/ArrowStreamReaderTests.cs
+++ b/test/Apache.Arrow.Compression.Tests/ArrowStreamReaderTests.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Reflection;
 using Apache.Arrow.Ipc;
+using Apache.Arrow.Memory;
 using Apache.Arrow.Tests;
 using Xunit;
 
@@ -47,11 +48,32 @@ namespace Apache.Arrow.Compression.Tests
             using var stream = assembly.GetManifestResourceStream($"Apache.Arrow.Compression.Tests.Resources.{fileName}");
             Assert.NotNull(stream);
             var buffer = new byte[stream.Length];
-            stream.ReadFullBuffer(buffer);
+            stream.ReadExactly(buffer);
             var codecFactory = new Compression.CompressionCodecFactory();
             using var reader = new ArrowStreamReader(buffer, codecFactory);
 
             VerifyCompressedIpcFileBatch(reader.ReadNextRecordBatch());
+        }
+
+        [Theory]
+        [InlineData("ipc_lz4_compression.arrow_stream")]
+        [InlineData("ipc_zstd_compression.arrow_stream")]
+        public void CanReadCompressedIpcStreamFromMemoryBuffer_UsesDefaultAllocator(string fileName)
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            using var stream = assembly.GetManifestResourceStream($"Apache.Arrow.Compression.Tests.Resources.{fileName}");
+            Assert.NotNull(stream);
+            var buffer = new byte[stream.Length];
+            stream.ReadExactly(buffer);
+            var codecFactory = new Compression.CompressionCodecFactory();
+
+            long allocationsBeforeRead = MemoryAllocator.Default.Value.Statistics.Allocations;
+
+            using var reader = new ArrowStreamReader(buffer, codecFactory);
+            using RecordBatch batch = reader.ReadNextRecordBatch();
+            VerifyCompressedIpcFileBatch(batch);
+
+            Assert.True(MemoryAllocator.Default.Value.Statistics.Allocations > allocationsBeforeRead);
         }
 
         [Fact]
@@ -103,4 +125,3 @@ namespace Apache.Arrow.Compression.Tests
         }
     }
 }
-

--- a/test/Apache.Arrow.Tests/ArrowStreamReaderTests.cs
+++ b/test/Apache.Arrow.Tests/ArrowStreamReaderTests.cs
@@ -409,6 +409,36 @@ namespace Apache.Arrow.Tests
             }
         }
 
+        [Fact]
+        public async Task ReadRecordBatchAsync_ExposedMemoryStream_BatchDoesNotAliasMutableStreamBuffer()
+        {
+            RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100, createDictionaryArray: false);
+            RecordBatch readBatch;
+            byte[] streamBuffer;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                ArrowStreamWriter writer = new ArrowStreamWriter(stream, originalBatch.Schema, leaveOpen: true);
+                await writer.WriteRecordBatchAsync(originalBatch);
+                await writer.WriteEndAsync();
+
+                streamBuffer = stream.GetBuffer();
+                stream.Position = 0;
+
+                using (ArrowStreamReader reader = new ArrowStreamReader(stream, leaveOpen: true))
+                {
+                    readBatch = await reader.ReadNextRecordBatchAsync();
+                }
+            }
+
+            System.Array.Clear(streamBuffer, 0, streamBuffer.Length);
+
+            using (readBatch)
+            {
+                ArrowReaderVerifier.CompareBatches(originalBatch, readBatch);
+            }
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/test/Apache.Arrow.Tests/ArrowStreamReaderTests.cs
+++ b/test/Apache.Arrow.Tests/ArrowStreamReaderTests.cs
@@ -14,11 +14,12 @@
 // limitations under the License.
 
 using System;
-using System.Buffers.Binary;
 using System.IO;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Apache.Arrow.Ipc;
+using Apache.Arrow.Memory;
 using Apache.Arrow.Types;
 using Xunit;
 
@@ -69,12 +70,19 @@ namespace Apache.Arrow.Tests
 
                 var memoryPool = new TestMemoryAllocator();
                 ArrowStreamReader reader = new ArrowStreamReader(stream, memoryPool, shouldLeaveOpen);
-                reader.ReadNextRecordBatch();
-
-                Assert.Equal(expectedAllocations, memoryPool.Statistics.Allocations);
-                Assert.True(memoryPool.Statistics.BytesAllocated > 0);
+                using (RecordBatch readBatch = reader.ReadNextRecordBatch())
+                {
+                    Assert.Equal(expectedAllocations, memoryPool.Statistics.Allocations);
+                    Assert.True(memoryPool.Statistics.BytesAllocated > 0);
+                    Assert.Equal(expectedAllocations, memoryPool.Rented);
+                }
 
                 reader.Dispose();
+
+                if (!createDictionaryArray)
+                {
+                    Assert.Equal(0, memoryPool.Rented);
+                }
 
                 if (shouldLeaveOpen)
                 {
@@ -109,6 +117,22 @@ namespace Apache.Arrow.Tests
             await TestReaderFromMemory(ArrowReaderVerifier.VerifyReaderAsync, writeEnd);
         }
 
+        [Fact]
+        public async Task ReadRecordBatch_Memory_ExactLengthSlice()
+        {
+            await TestReaderFromMemoryExactLength((reader, originalBatch) =>
+            {
+                ArrowReaderVerifier.VerifyReader(reader, originalBatch);
+                return Task.CompletedTask;
+            });
+        }
+
+        [Fact]
+        public async Task ReadRecordBatchAsync_Memory_ExactLengthSlice()
+        {
+            await TestReaderFromMemoryExactLength(ArrowReaderVerifier.VerifyReaderAsync);
+        }
+
         private static async Task TestReaderFromMemory(
             Func<ArrowStreamReader, RecordBatch, Task> verificationFunc,
             bool writeEnd)
@@ -125,6 +149,24 @@ namespace Apache.Arrow.Tests
                     await writer.WriteEndAsync();
                 }
                 buffer = stream.GetBuffer();
+            }
+
+            ArrowStreamReader reader = new ArrowStreamReader(buffer);
+            await verificationFunc(reader, originalBatch);
+        }
+
+        private static async Task TestReaderFromMemoryExactLength(
+            Func<ArrowStreamReader, RecordBatch, Task> verificationFunc)
+        {
+            RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100);
+
+            ReadOnlyMemory<byte> buffer;
+            using (MemoryStream stream = new MemoryStream())
+            {
+                ArrowStreamWriter writer = new ArrowStreamWriter(stream, originalBatch.Schema);
+                await writer.WriteRecordBatchAsync(originalBatch);
+                await writer.WriteEndAsync();
+                buffer = stream.GetBuffer().AsMemory(0, checked((int)stream.Length));
             }
 
             ArrowStreamReader reader = new ArrowStreamReader(buffer);
@@ -167,6 +209,40 @@ namespace Apache.Arrow.Tests
             }
         }
 
+        [Fact]
+        public async Task ReadRecordBatchAsync_PassesCancellationTokenToSchemaRead()
+        {
+            using var stream = new RequiresCancelableReadStream();
+            using var reader = new ArrowStreamReader(stream);
+            using var cancellation = new CancellationTokenSource();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+                await reader.ReadNextRecordBatchAsync(cancellation.Token));
+
+            Assert.True(stream.SawCancelableToken);
+        }
+
+        [Fact]
+        public async Task ReadRecordBatchAsync_Stream_DictionaryFixtureWithoutRee()
+        {
+            using RecordBatch originalBatch = TestData.CreateSampleRecordBatch(
+                length: 100,
+                columnSetCount: 5,
+                excludedTypes: new System.Collections.Generic.HashSet<ArrowTypeId> { ArrowTypeId.RunEndEncoded });
+
+            using var stream = new MemoryStream();
+            using (ArrowStreamWriter writer = new ArrowStreamWriter(stream, originalBatch.Schema, leaveOpen: true))
+            {
+                await writer.WriteRecordBatchAsync(originalBatch);
+                await writer.WriteEndAsync();
+            }
+
+            stream.Position = 0;
+
+            using var reader = new ArrowStreamReader(stream);
+            await ArrowReaderVerifier.VerifyReaderAsync(reader, originalBatch);
+        }
+
         [Theory]
         [InlineData(true, true)]
         [InlineData(true, false)]
@@ -175,6 +251,84 @@ namespace Apache.Arrow.Tests
         public async Task ReadRecordBatchAsync_Stream(bool writeEnd, bool createDictionaryArray)
         {
             await TestReaderFromStream(ArrowReaderVerifier.VerifyReaderAsync, writeEnd, createDictionaryArray);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ReadRecordBatchAsync_NonPubliclyVisibleMemoryStream(bool createDictionaryArray)
+        {
+            RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100, createDictionaryArray: createDictionaryArray);
+
+            byte[] buffer;
+            using (MemoryStream stream = new MemoryStream())
+            {
+                ArrowStreamWriter writer = new ArrowStreamWriter(stream, originalBatch.Schema, leaveOpen: true);
+                await writer.WriteRecordBatchAsync(originalBatch);
+                await writer.WriteEndAsync();
+                buffer = stream.ToArray();
+            }
+
+            using (MemoryStream stream = new MemoryStream(buffer))
+            {
+                ArrowStreamReader reader = new ArrowStreamReader(stream);
+                await ArrowReaderVerifier.VerifyReaderAsync(reader, originalBatch);
+            }
+        }
+
+        [Fact]
+        public async Task ReadRecordBatchAsync_NonPubliclyVisibleMemoryStream_UsesExplicitAllocator()
+        {
+            RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100, createDictionaryArray: false);
+
+            byte[] buffer;
+            using (MemoryStream stream = new MemoryStream())
+            {
+                ArrowStreamWriter writer = new ArrowStreamWriter(stream, originalBatch.Schema, leaveOpen: true);
+                await writer.WriteRecordBatchAsync(originalBatch);
+                await writer.WriteEndAsync();
+                buffer = stream.ToArray();
+            }
+
+            var allocator = new TestMemoryAllocator();
+            using (MemoryStream stream = new MemoryStream(buffer))
+            using (var reader = new ArrowStreamReader(stream, allocator))
+            {
+                using (RecordBatch readBatch = await reader.ReadNextRecordBatchAsync())
+                {
+                    ArrowReaderVerifier.CompareBatches(originalBatch, readBatch);
+                }
+
+                Assert.True(allocator.Statistics.Allocations > 0);
+                Assert.Equal(0, allocator.Rented);
+                Assert.Null(await reader.ReadNextRecordBatchAsync());
+            }
+        }
+
+        [Fact]
+        public async Task ReadRecordBatchAsync_NonPubliclyVisibleMemoryStream_UsesDefaultAllocator()
+        {
+            RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100, createDictionaryArray: false);
+
+            byte[] buffer;
+            using (MemoryStream stream = new MemoryStream())
+            {
+                ArrowStreamWriter writer = new ArrowStreamWriter(stream, originalBatch.Schema, leaveOpen: true);
+                await writer.WriteRecordBatchAsync(originalBatch);
+                await writer.WriteEndAsync();
+                buffer = stream.ToArray();
+            }
+
+            long allocationsBeforeRead = MemoryAllocator.Default.Value.Statistics.Allocations;
+
+            using (MemoryStream stream = new MemoryStream(buffer))
+            using (var reader = new ArrowStreamReader(stream, MemoryAllocator.Default.Value))
+            using (RecordBatch readBatch = await reader.ReadNextRecordBatchAsync())
+            {
+                ArrowReaderVerifier.CompareBatches(originalBatch, readBatch);
+            }
+
+            Assert.True(MemoryAllocator.Default.Value.Statistics.Allocations > allocationsBeforeRead);
         }
 
         private static async Task TestReaderFromStream(
@@ -196,6 +350,62 @@ namespace Apache.Arrow.Tests
 
                 ArrowStreamReader reader = new ArrowStreamReader(stream);
                 await verificationFunc(reader, originalBatch);
+            }
+        }
+
+        [Fact]
+        public async Task ReadRecordBatch_ExposedMemoryStream_BatchRemainsUsableAfterDispose()
+        {
+            RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100, createDictionaryArray: false);
+            RecordBatch readBatch;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                ArrowStreamWriter writer = new ArrowStreamWriter(stream, originalBatch.Schema, leaveOpen: true);
+                await writer.WriteRecordBatchAsync(originalBatch);
+                await writer.WriteEndAsync();
+
+                stream.Position = 0;
+
+                using (ArrowStreamReader reader = new ArrowStreamReader(stream, leaveOpen: true))
+                {
+                    readBatch = reader.ReadNextRecordBatch();
+                }
+            }
+
+            using (readBatch)
+            {
+                ArrowReaderVerifier.CompareBatches(originalBatch, readBatch);
+            }
+        }
+
+        [Fact]
+        public async Task ReadRecordBatch_ExposedMemoryStream_BatchDoesNotAliasMutableStreamBuffer()
+        {
+            RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100, createDictionaryArray: false);
+            RecordBatch readBatch;
+            byte[] streamBuffer;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                ArrowStreamWriter writer = new ArrowStreamWriter(stream, originalBatch.Schema, leaveOpen: true);
+                await writer.WriteRecordBatchAsync(originalBatch);
+                await writer.WriteEndAsync();
+
+                streamBuffer = stream.GetBuffer();
+                stream.Position = 0;
+
+                using (ArrowStreamReader reader = new ArrowStreamReader(stream, leaveOpen: true))
+                {
+                    readBatch = reader.ReadNextRecordBatch();
+                }
+            }
+
+            System.Array.Clear(streamBuffer, 0, streamBuffer.Length);
+
+            using (readBatch)
+            {
+                ArrowReaderVerifier.CompareBatches(originalBatch, readBatch);
             }
         }
 
@@ -243,10 +453,33 @@ namespace Apache.Arrow.Tests
         /// <summary>
         /// A stream class that only returns a part of the data at a time.
         /// </summary>
-        private class PartialReadStream : MemoryStream
+        private class PartialReadStream : Stream
         {
+            private readonly MemoryStream _innerStream = new MemoryStream();
+
             // by default return 20 bytes at a time
             public int PartialReadLength { get; set; } = 20;
+
+            public override bool CanRead => _innerStream.CanRead;
+            public override bool CanSeek => _innerStream.CanSeek;
+            public override bool CanWrite => _innerStream.CanWrite;
+            public override long Length => _innerStream.Length;
+            public override long Position { get => _innerStream.Position; set => _innerStream.Position = value; }
+
+            public override void Flush() => _innerStream.Flush();
+            public override long Seek(long offset, SeekOrigin origin) => _innerStream.Seek(offset, origin);
+            public override void SetLength(long value) => _innerStream.SetLength(value);
+            public override void Write(byte[] buffer, int offset, int count) => _innerStream.Write(buffer, offset, count);
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                return _innerStream.Read(buffer, offset, Math.Min(count, PartialReadLength));
+            }
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
+            {
+                return _innerStream.ReadAsync(buffer, offset, Math.Min(count, PartialReadLength), cancellationToken);
+            }
 
 #if NET5_0_OR_GREATER
             public override int Read(Span<byte> destination)
@@ -256,7 +489,7 @@ namespace Apache.Arrow.Tests
                     destination = destination.Slice(0, PartialReadLength);
                 }
 
-                return base.Read(destination);
+                return _innerStream.Read(destination);
             }
 
             public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default)
@@ -266,17 +499,48 @@ namespace Apache.Arrow.Tests
                     destination = destination.Slice(0, PartialReadLength);
                 }
 
-                return base.ReadAsync(destination, cancellationToken);
+                return _innerStream.ReadAsync(destination, cancellationToken);
+            }
+#endif
+        }
+
+        private class RequiresCancelableReadStream : Stream
+        {
+            public bool SawCancelableToken { get; private set; }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+            public override void Flush() { }
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+#if NET5_0_OR_GREATER
+            public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                SawCancelableToken = cancellationToken.CanBeCanceled;
+                if (!SawCancelableToken)
+                {
+                    throw new InvalidOperationException("Expected the caller's cancellation token during schema read.");
+                }
+
+                throw new OperationCanceledException(cancellationToken);
             }
 #else
-            public override int Read(byte[] buffer, int offset, int length)
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
-                return base.Read(buffer, offset, Math.Min(length, PartialReadLength));
-            }
+                SawCancelableToken = cancellationToken.CanBeCanceled;
+                if (!SawCancelableToken)
+                {
+                    throw new InvalidOperationException("Expected the caller's cancellation token during schema read.");
+                }
 
-            public override Task<int> ReadAsync(byte[] buffer, int offset, int length, CancellationToken cancellationToken = default)
-            {
-                return base.ReadAsync(buffer, offset, Math.Min(length, PartialReadLength), cancellationToken);
+                throw new OperationCanceledException(cancellationToken);
             }
 #endif
         }
@@ -316,163 +580,6 @@ namespace Apache.Arrow.Tests
         }
 
         [Fact]
-        public void MalformedBodyLength_OverflowsInt32()
-        {
-            byte[] buffer = BuildSimpleInt32Batch(rowCount: 3);
-            int messageStart = FindRecordBatchMessageStart(buffer);
-            int messageTablePos = ReadRootTablePos(buffer, messageStart);
-
-            // Message table vtable slot 10 = BodyLength
-            int bodyLengthPos = ReadFieldAbsolutePos(buffer, messageTablePos, vtableSlot: 10);
-            Assert.True(ToInt64LittleEndian(buffer, bodyLengthPos) > 0);
-
-            WriteInt64LittleEndian(buffer, bodyLengthPos, (long)int.MaxValue + 1);
-
-            InvalidDataException ex = Assert.Throws<InvalidDataException>(
-                () => new ArrowStreamReader(buffer).ReadNextRecordBatch());
-            Assert.Contains("Message body", ex.Message);
-            Assert.Contains("out of range", ex.Message);
-        }
-
-        [Fact]
-        public void MalformedRecordBatchLength_OverflowsInt32()
-        {
-            byte[] buffer = BuildSimpleInt32Batch(rowCount: 3);
-            int messageStart = FindRecordBatchMessageStart(buffer);
-            int messageTablePos = ReadRootTablePos(buffer, messageStart);
-
-            // Message.Header (slot 8) is a union pointing at the RecordBatch table
-            int recordBatchTablePos = ReadUnionTablePos(buffer, messageTablePos, vtableSlot: 8);
-
-            // RecordBatch table vtable slot 4 = Length (row count)
-            int lengthPos = ReadFieldAbsolutePos(buffer, recordBatchTablePos, vtableSlot: 4);
-            Assert.Equal(3L, ToInt64LittleEndian(buffer, lengthPos));
-
-            WriteInt64LittleEndian(buffer, lengthPos, (long)int.MaxValue + 1);
-
-            InvalidDataException ex = Assert.Throws<InvalidDataException>(
-                () => new ArrowStreamReader(buffer).ReadNextRecordBatch());
-            Assert.Contains("out of range", ex.Message);
-        }
-
-        [Fact]
-        public void MalformedFieldNodeLength_OverflowsInt32()
-        {
-            byte[] buffer = BuildSimpleInt32Batch(rowCount: 3);
-            int messageStart = FindRecordBatchMessageStart(buffer);
-            int messageTablePos = ReadRootTablePos(buffer, messageStart);
-            int recordBatchTablePos = ReadUnionTablePos(buffer, messageTablePos, vtableSlot: 8);
-
-            // RecordBatch.Nodes (slot 6) is a vector of 16-byte FieldNode structs
-            // where the first 8 bytes are Length and the next 8 bytes are NullCount.
-            int nodesDataStart = ReadVectorDataStart(buffer, recordBatchTablePos, vtableSlot: 6);
-            Assert.Equal(3L, ToInt64LittleEndian(buffer, nodesDataStart));
-
-            WriteInt64LittleEndian(buffer, nodesDataStart, (long)int.MaxValue + 1);
-
-            InvalidDataException ex = Assert.Throws<InvalidDataException>(
-                () => new ArrowStreamReader(buffer).ReadNextRecordBatch());
-            Assert.Contains("Field length", ex.Message);
-        }
-
-        [Fact]
-        public void MalformedBufferLength_OverflowsInt32()
-        {
-            byte[] buffer = BuildSimpleInt32Batch(rowCount: 3);
-            int messageStart = FindRecordBatchMessageStart(buffer);
-            int messageTablePos = ReadRootTablePos(buffer, messageStart);
-            int recordBatchTablePos = ReadUnionTablePos(buffer, messageTablePos, vtableSlot: 8);
-
-            // RecordBatch.Buffers (slot 8) is a vector of 16-byte Buffer structs
-            // (8 bytes Offset, 8 bytes Length). Find the first buffer with non-zero
-            // length and corrupt its Length field.
-            int buffersDataStart = ReadVectorDataStart(buffer, recordBatchTablePos, vtableSlot: 8);
-            int buffersLength = ToInt32LittleEndian(buffer, buffersDataStart - 4);
-            int targetLengthPos = -1;
-            for (int i = 0; i < buffersLength; i++)
-            {
-                int lengthPos = buffersDataStart + i * 16 + 8;
-                if (ToInt64LittleEndian(buffer, lengthPos) > 0)
-                {
-                    targetLengthPos = lengthPos;
-                    break;
-                }
-            }
-            Assert.NotEqual(-1, targetLengthPos);
-
-            WriteInt64LittleEndian(buffer, targetLengthPos, (long)int.MaxValue + 1);
-
-            InvalidDataException ex = Assert.Throws<InvalidDataException>(
-                () => new ArrowStreamReader(buffer).ReadNextRecordBatch());
-            Assert.Contains("IPC buffer range", ex.Message);
-        }
-
-        private static byte[] BuildSimpleInt32Batch(int rowCount)
-        {
-            Schema schema = new(
-                [new Field("x", Int32Type.Default, nullable: true)],
-                metadata: []);
-            Int32Array.Builder arrayBuilder = new();
-            for (int i = 0; i < rowCount; i++)
-            {
-                arrayBuilder.Append(i);
-            }
-            RecordBatch batch = new(schema, [arrayBuilder.Build()], rowCount);
-
-            using MemoryStream stream = new();
-            using (ArrowStreamWriter writer = new(stream, schema, leaveOpen: true))
-            {
-                writer.WriteRecordBatch(batch);
-                writer.WriteEnd();
-            }
-            return stream.ToArray();
-        }
-
-        private static int FindRecordBatchMessageStart(byte[] buffer)
-        {
-            // Stream layout: [continuation(0xFFFFFFFF)][len][schema message][continuation][len][batch message][body]...
-            int pos = 0;
-            Assert.Equal(-1, ToInt32LittleEndian(buffer, pos)); pos += 4;
-            int schemaLen = ToInt32LittleEndian(buffer, pos); pos += 4;
-            pos += schemaLen;
-            Assert.Equal(-1, ToInt32LittleEndian(buffer, pos)); pos += 4;
-            pos += 4; // batch message length prefix
-            return pos;
-        }
-
-        private static int ReadRootTablePos(byte[] buffer, int messageStart)
-        {
-            return messageStart + ToInt32LittleEndian(buffer, messageStart);
-        }
-
-        private static int ReadFieldAbsolutePos(byte[] buffer, int tablePos, int vtableSlot)
-        {
-            int vtable = tablePos - ToInt32LittleEndian(buffer, tablePos);
-            short fieldOffset = ToInt16LittleEndian(buffer, vtable + vtableSlot);
-            Assert.NotEqual(0, fieldOffset); // field must be present in the vtable
-            return tablePos + fieldOffset;
-        }
-
-        private static int ReadUnionTablePos(byte[] buffer, int tablePos, int vtableSlot)
-        {
-            int unionPtrPos = ReadFieldAbsolutePos(buffer, tablePos, vtableSlot);
-            return unionPtrPos + ToInt32LittleEndian(buffer, unionPtrPos);
-        }
-
-        private static int ReadVectorDataStart(byte[] buffer, int tablePos, int vtableSlot)
-        {
-            int vectorPtrPos = ReadFieldAbsolutePos(buffer, tablePos, vtableSlot);
-            int vectorLengthPos = vectorPtrPos + ToInt32LittleEndian(buffer, vectorPtrPos);
-            return vectorLengthPos + 4; // skip the 4-byte vector length prefix
-        }
-
-        private static void WriteInt64LittleEndian(byte[] buffer, int offset, long value)
-        {
-            System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(
-                buffer.AsSpan(offset), value);
-        }
-
-        [Fact]
         public async Task EmptyStreamNoSyncRead()
         {
             using (var stream = new EmptyAsyncOnlyStream())
@@ -481,21 +588,6 @@ namespace Apache.Arrow.Tests
                 var schema = await reader.GetSchema();
                 Assert.Null(schema);
             }
-        }
-
-        private static short ToInt16LittleEndian(byte[] buffer, int offset)
-        {
-            return BinaryPrimitives.ReadInt16LittleEndian(buffer.AsSpan().Slice(offset));
-        }
-
-        private static int ToInt32LittleEndian(byte[] buffer, int offset)
-        {
-            return BinaryPrimitives.ReadInt32LittleEndian(buffer.AsSpan().Slice(offset));
-        }
-
-        private static long ToInt64LittleEndian(byte[] buffer, int offset)
-        {
-            return BinaryPrimitives.ReadInt64LittleEndian(buffer.AsSpan().Slice(offset));
         }
 
         private class EmptyAsyncOnlyStream : Stream

--- a/test/Apache.Arrow.Tests/ArrowStreamReaderTests.cs
+++ b/test/Apache.Arrow.Tests/ArrowStreamReaderTests.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using System;
+using System.Buffers.Binary;
 using System.IO;
 using System.Reflection;
 using System.Threading;
@@ -576,6 +577,162 @@ namespace Apache.Arrow.Tests
         }
 
         [Fact]
+        public void MalformedBodyLength_OverflowsInt32()
+        {
+            byte[] buffer = BuildSimpleInt32Batch(rowCount: 3);
+            int messageStart = FindRecordBatchMessageStart(buffer);
+            int messageTablePos = ReadRootTablePos(buffer, messageStart);
+
+            // Message table vtable slot 10 = BodyLength
+            int bodyLengthPos = ReadFieldAbsolutePos(buffer, messageTablePos, vtableSlot: 10);
+            Assert.True(ToInt64LittleEndian(buffer, bodyLengthPos) > 0);
+
+            WriteInt64LittleEndian(buffer, bodyLengthPos, (long)int.MaxValue + 1);
+
+            InvalidDataException ex = Assert.Throws<InvalidDataException>(
+                () => new ArrowStreamReader(buffer).ReadNextRecordBatch());
+            Assert.Contains("Message body", ex.Message);
+            Assert.Contains("out of range", ex.Message);
+        }
+
+        [Fact]
+        public void MalformedRecordBatchLength_OverflowsInt32()
+        {
+            byte[] buffer = BuildSimpleInt32Batch(rowCount: 3);
+            int messageStart = FindRecordBatchMessageStart(buffer);
+            int messageTablePos = ReadRootTablePos(buffer, messageStart);
+
+            // Message.Header (slot 8) is a union pointing at the RecordBatch table
+            int recordBatchTablePos = ReadUnionTablePos(buffer, messageTablePos, vtableSlot: 8);
+
+            // RecordBatch table vtable slot 4 = Length (row count)
+            int lengthPos = ReadFieldAbsolutePos(buffer, recordBatchTablePos, vtableSlot: 4);
+            Assert.Equal(3L, ToInt64LittleEndian(buffer, lengthPos));
+
+            WriteInt64LittleEndian(buffer, lengthPos, (long)int.MaxValue + 1);
+
+            InvalidDataException ex = Assert.Throws<InvalidDataException>(
+                () => new ArrowStreamReader(buffer).ReadNextRecordBatch());
+            Assert.Contains("out of range", ex.Message);
+        }
+
+        [Fact]
+        public void MalformedFieldNodeLength_OverflowsInt32()
+        {
+            byte[] buffer = BuildSimpleInt32Batch(rowCount: 3);
+            int messageStart = FindRecordBatchMessageStart(buffer);
+            int messageTablePos = ReadRootTablePos(buffer, messageStart);
+            int recordBatchTablePos = ReadUnionTablePos(buffer, messageTablePos, vtableSlot: 8);
+
+            // RecordBatch.Nodes (slot 6) is a vector of 16-byte FieldNode structs
+            // where the first 8 bytes are Length and the next 8 bytes are NullCount.
+            int nodesDataStart = ReadVectorDataStart(buffer, recordBatchTablePos, vtableSlot: 6);
+            Assert.Equal(3L, ToInt64LittleEndian(buffer, nodesDataStart));
+
+            WriteInt64LittleEndian(buffer, nodesDataStart, (long)int.MaxValue + 1);
+
+            InvalidDataException ex = Assert.Throws<InvalidDataException>(
+                () => new ArrowStreamReader(buffer).ReadNextRecordBatch());
+            Assert.Contains("Field length", ex.Message);
+        }
+
+        [Fact]
+        public void MalformedBufferLength_OverflowsInt32()
+        {
+            byte[] buffer = BuildSimpleInt32Batch(rowCount: 3);
+            int messageStart = FindRecordBatchMessageStart(buffer);
+            int messageTablePos = ReadRootTablePos(buffer, messageStart);
+            int recordBatchTablePos = ReadUnionTablePos(buffer, messageTablePos, vtableSlot: 8);
+
+            // RecordBatch.Buffers (slot 8) is a vector of 16-byte Buffer structs
+            // (8 bytes Offset, 8 bytes Length). Find the first buffer with non-zero
+            // length and corrupt its Length field.
+            int buffersDataStart = ReadVectorDataStart(buffer, recordBatchTablePos, vtableSlot: 8);
+            int buffersLength = ToInt32LittleEndian(buffer, buffersDataStart - 4);
+            int targetLengthPos = -1;
+            for (int i = 0; i < buffersLength; i++)
+            {
+                int lengthPos = buffersDataStart + i * 16 + 8;
+                if (ToInt64LittleEndian(buffer, lengthPos) > 0)
+                {
+                    targetLengthPos = lengthPos;
+                    break;
+                }
+            }
+            Assert.NotEqual(-1, targetLengthPos);
+
+            WriteInt64LittleEndian(buffer, targetLengthPos, (long)int.MaxValue + 1);
+
+            InvalidDataException ex = Assert.Throws<InvalidDataException>(
+                () => new ArrowStreamReader(buffer).ReadNextRecordBatch());
+            Assert.Contains("IPC buffer range", ex.Message);
+        }
+
+        private static byte[] BuildSimpleInt32Batch(int rowCount)
+        {
+            Schema schema = new(
+                [new Field("x", Int32Type.Default, nullable: true)],
+                metadata: []);
+            Int32Array.Builder arrayBuilder = new();
+            for (int i = 0; i < rowCount; i++)
+            {
+                arrayBuilder.Append(i);
+            }
+            RecordBatch batch = new(schema, [arrayBuilder.Build()], rowCount);
+
+            using MemoryStream stream = new();
+            using (ArrowStreamWriter writer = new(stream, schema, leaveOpen: true))
+            {
+                writer.WriteRecordBatch(batch);
+                writer.WriteEnd();
+            }
+            return stream.ToArray();
+        }
+
+        private static int FindRecordBatchMessageStart(byte[] buffer)
+        {
+            // Stream layout: [continuation(0xFFFFFFFF)][len][schema message][continuation][len][batch message][body]...
+            int pos = 0;
+            Assert.Equal(-1, ToInt32LittleEndian(buffer, pos)); pos += 4;
+            int schemaLen = ToInt32LittleEndian(buffer, pos); pos += 4;
+            pos += schemaLen;
+            Assert.Equal(-1, ToInt32LittleEndian(buffer, pos)); pos += 4;
+            pos += 4; // batch message length prefix
+            return pos;
+        }
+
+        private static int ReadRootTablePos(byte[] buffer, int messageStart)
+        {
+            return messageStart + ToInt32LittleEndian(buffer, messageStart);
+        }
+
+        private static int ReadFieldAbsolutePos(byte[] buffer, int tablePos, int vtableSlot)
+        {
+            int vtable = tablePos - ToInt32LittleEndian(buffer, tablePos);
+            short fieldOffset = ToInt16LittleEndian(buffer, vtable + vtableSlot);
+            Assert.NotEqual(0, fieldOffset); // field must be present in the vtable
+            return tablePos + fieldOffset;
+        }
+
+        private static int ReadUnionTablePos(byte[] buffer, int tablePos, int vtableSlot)
+        {
+            int unionPtrPos = ReadFieldAbsolutePos(buffer, tablePos, vtableSlot);
+            return unionPtrPos + ToInt32LittleEndian(buffer, unionPtrPos);
+        }
+
+        private static int ReadVectorDataStart(byte[] buffer, int tablePos, int vtableSlot)
+        {
+            int vectorPtrPos = ReadFieldAbsolutePos(buffer, tablePos, vtableSlot);
+            int vectorLengthPos = vectorPtrPos + ToInt32LittleEndian(buffer, vectorPtrPos);
+            return vectorLengthPos + 4; // skip the 4-byte vector length prefix
+        }
+
+        private static void WriteInt64LittleEndian(byte[] buffer, int offset, long value)
+        {
+            BinaryPrimitives.WriteInt64LittleEndian(buffer.AsSpan(offset), value);
+        }
+
+        [Fact]
         public unsafe void MalformedColumnNameLength()
         {
             const int FieldNameLengthOffset = 108;
@@ -633,6 +790,21 @@ namespace Apache.Arrow.Tests
             public override void SetLength(long value) => throw new NotSupportedException();
             public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
             public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => Task.FromResult(0);
+        }
+
+        private static short ToInt16LittleEndian(byte[] buffer, int offset)
+        {
+            return BinaryPrimitives.ReadInt16LittleEndian(buffer.AsSpan().Slice(offset));
+        }
+
+        private static int ToInt32LittleEndian(byte[] buffer, int offset)
+        {
+            return BinaryPrimitives.ReadInt32LittleEndian(buffer.AsSpan().Slice(offset));
+        }
+
+        private static long ToInt64LittleEndian(byte[] buffer, int offset)
+        {
+            return BinaryPrimitives.ReadInt64LittleEndian(buffer.AsSpan().Slice(offset));
         }
     }
 }


### PR DESCRIPTION
## Summary

This improves `ArrowStreamReader` when reading from `MemoryStream` instances that expose their underlying buffer. The reader now uses the exposed buffer for IPC message/schema metadata reads while preserving the existing reader-owned body-buffer boundary.

The change is intentionally scoped to MemoryStream-backed IPC stream reads:

- public/exposed `MemoryStream` can use the fast path
- non-public `MemoryStream` and partial-read streams continue through the fallback stream-read path
- record batch body data is still copied into allocator-owned memory before array construction
- `ArrowMemoryReader` exact-length continuation-token handling is corrected for complete in-memory buffers

## Benchmark

BenchmarkDotNet ShortRun, `ArrowReaderBenchmark`:

| Scenario | Before | After |
|---|---:|---:|
| `ArrowReaderWithMemoryStream_ManagedMemory`, 100000 rows / 1 column | 21629.3 us | 7707.6 us |
| `ArrowReaderWithMemoryStream_ManagedMemory`, 100000 rows / 5 columns | 91112.3 us | 40137.5 us |

## Validation

- `dotnet test test/Apache.Arrow.Tests/Apache.Arrow.Tests.csproj -c Release --filter "FullyQualifiedName~Apache.Arrow.Tests.ArrowStreamReaderTests"`
- `dotnet test test/Apache.Arrow.Compression.Tests/Apache.Arrow.Compression.Tests.csproj -c Release --filter "FullyQualifiedName~Apache.Arrow.Compression.Tests.ArrowStreamReaderTests"`
- `dotnet build Apache.Arrow.sln -c Release`