### PR TITLE
chore: Bump Zstd.Sharp from 0.8.5 to 0.8.8

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,6 +52,6 @@
                     Version="2.8.2"
                     Condition="'$(TargetFramework)' == 'net462'" />
     <PackageVersion Include="xunit.skippablefact" Version="1.5.61" />
-    <PackageVersion Include="ZstdSharp.Port" Version="0.8.5" />
+    <PackageVersion Include="ZstdSharp.Port" Version="0.8.8" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## What's Changed

Bump the `Zstd.Sharp` package from 0.8.5 to 0.8.8. The main reason for this bump is to bring that project's dependency `System.Memory` up to v4.6.0, and is implemented in [this PR](https://github.com/oleg-st/ZstdSharp/pull/69). 

I implemented this change in `Zstd.Sharp` to fix a version mismatch issue; I am working on a plugin for use in [`Bonsai-Rx`](https://github.com/bonsai-rx/bonsai), which does not allow me to have an assembly binding redirect, leading to a run-time exception due to multiple `System.Memory` versions present.

All tests passed locally, and all builds succeeded.