### PR TITLE
docs: Remove Run End Encoding from Not Implemented

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -131,7 +131,6 @@ Example demonstrating reading [RecordBatches](xref:Apache.Arrow.RecordBatch) fro
 
 - Serialization
     - Exhaustive validation
-    - Run End Encoding
 - Types
     - Tensor
 - Arrays


### PR DESCRIPTION
## What's Changed

This feature is implemented as of v23.0.0 release (PR #308), 
so it was removed from the  "Not Implemented" section of the docs.