### PR TITLE
Fix integration tests by modifying CompareVariadicArrays

### DIFF
--- a/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
+++ b/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
@@ -362,7 +362,7 @@ namespace Apache.Arrow.Tests
 
                 CompareValidityBuffer(expectedArray.NullCount, _expectedArray.Length, expectedArray.NullBitmapBuffer, expectedArray.Offset, actualArray.NullBitmapBuffer, actualArray.Offset);
 
-                Assert.True(expectedArray.Views.SequenceEqual(actualArray.Views));
+                // Assert.True(expectedArray.Views.SequenceEqual(actualArray.Views));
 
                 for (int i = 0; i < expectedArray.Length; i++)
                 {

--- a/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
+++ b/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
@@ -362,8 +362,6 @@ namespace Apache.Arrow.Tests
 
                 CompareValidityBuffer(expectedArray.NullCount, _expectedArray.Length, expectedArray.NullBitmapBuffer, expectedArray.Offset, actualArray.NullBitmapBuffer, actualArray.Offset);
 
-                // Assert.True(expectedArray.Views.SequenceEqual(actualArray.Views));
-
                 for (int i = 0; i < expectedArray.Length; i++)
                 {
                     Assert.True(

--- a/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
+++ b/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
@@ -362,6 +362,11 @@ namespace Apache.Arrow.Tests
 
                 CompareValidityBuffer(expectedArray.NullCount, _expectedArray.Length, expectedArray.NullBitmapBuffer, expectedArray.Offset, actualArray.NullBitmapBuffer, actualArray.Offset);
 
+                if (_strictCompare)
+                {
+                    Assert.True(expectedArray.Views.SequenceEqual(actualArray.Views));
+                }
+
                 for (int i = 0; i < expectedArray.Length; i++)
                 {
                     Assert.True(


### PR DESCRIPTION
## What's Changed

Fix integration tests by modifying `CompareVariadicArrays` so that it only does a direct buffer comparison when `_strictCompare` is enabled.

Fixes #359