### PR TITLE
feat: remove most calls to GC memory pressure APIs

### DIFF
--- a/src/Apache.Arrow/Memory/ExportedAllocationOwner.cs
+++ b/src/Apache.Arrow/Memory/ExportedAllocationOwner.cs
@@ -26,7 +26,6 @@ namespace Apache.Arrow.Memory
         private readonly List<IntPtr> _pointers = new List<IntPtr>();
         private readonly List<MemoryHandle> _handles = new List<MemoryHandle>();
         private readonly List<SharedMemoryHandle> _sharedHandles = new List<SharedMemoryHandle>();
-        private long _allocationSize;
         private long _referenceCount;
         private bool _disposed;
 
@@ -37,14 +36,12 @@ namespace Apache.Arrow.Memory
 
         public IntPtr Allocate(int size)
         {
-            GC.AddMemoryPressure(size);
             return Acquire(Marshal.AllocHGlobal(size), 0, size);
         }
 
         public IntPtr Acquire(IntPtr ptr, int offset, int length)
         {
             _pointers.Add(ptr);
-            _allocationSize += length;
             return ptr;
         }
 
@@ -103,7 +100,6 @@ namespace Apache.Arrow.Memory
                 _sharedHandles[i] = default;
             }
 
-            GC.RemoveMemoryPressure(_allocationSize);
             GC.SuppressFinalize(this);
             _disposed = true;
         }

--- a/src/Apache.Arrow/Memory/ImportedAllocationOwner.cs
+++ b/src/Apache.Arrow/Memory/ImportedAllocationOwner.cs
@@ -41,7 +41,6 @@ namespace Apache.Arrow.Memory
             if (length > 0)
             {
                 Interlocked.Add(ref _managedMemory, length);
-                GC.AddMemoryPressure(length);
             }
             return memory;
         }
@@ -55,10 +54,6 @@ namespace Apache.Arrow.Memory
         {
             if (Interlocked.Decrement(ref _referenceCount) == 0)
             {
-                if (_managedMemory > 0)
-                {
-                    GC.RemoveMemoryPressure(_managedMemory);
-                }
                 FinalRelease();
             }
         }

--- a/src/Apache.Arrow/Memory/MemoryPressureAllocationTracker.cs
+++ b/src/Apache.Arrow/Memory/MemoryPressureAllocationTracker.cs
@@ -20,7 +20,8 @@ namespace Apache.Arrow.Memory
     /// <summary>
     /// Allows control over the way native allocations interact with the GC.
     /// </summary>
-    public struct MemoryPressureAllocationTracker : INativeAllocationTracker
+    [Obsolete("Use NoOpAllocationTracker instead. See https://learn.microsoft.com/en-us/dotnet/api/system.gc.addmemorypressure?view=net-10.0#remarks for more information on why the GC memory pressure APIs are not always necessary.")]
+    public readonly struct MemoryPressureAllocationTracker : INativeAllocationTracker
     {
         public void Track(int count, long bytes)
         {

--- a/src/Apache.Arrow/Memory/NativeMemoryAllocator.cs
+++ b/src/Apache.Arrow/Memory/NativeMemoryAllocator.cs
@@ -31,7 +31,7 @@ namespace Apache.Arrow.Memory
             // TODO: Ensure memory is released if exception occurs.
 
             // TODO: Optimize storage overhead; native memory manager stores a pointer
-            // to allocated memory, offset, and the allocation size. 
+            // to allocated memory, offset, and the allocation size.
 
             // TODO: Should the allocation be moved to NativeMemory?
 
@@ -41,8 +41,6 @@ namespace Apache.Arrow.Memory
             var manager = new NativeMemoryManager(ptr, offset, length);
 
             bytesAllocated = (length + Alignment);
-
-            GC.AddMemoryPressure(bytesAllocated);
 
             // Ensure all allocated memory is zeroed.
             manager.Memory.Span.Fill(0);
@@ -55,7 +53,6 @@ namespace Apache.Arrow.Memory
             public void Release(IntPtr ptr, int offset, int length)
             {
                 Marshal.FreeHGlobal(ptr);
-                GC.RemoveMemoryPressure(length + DefaultAlignment); // See https://github.com/apache/arrow-dotnet/issues/50
             }
         }
     }

--- a/src/Apache.Arrow/Memory/NoOpAllocationTracker.cs
+++ b/src/Apache.Arrow/Memory/NoOpAllocationTracker.cs
@@ -16,10 +16,9 @@
 namespace Apache.Arrow.Memory
 {
     /// <summary>
-    /// Avoid informing the GC about native allocations. Consider using for micro-benchmarks where
-    /// the impact of GC.AddMemoryPressure and GC.RemoveMemoryPressure can skew timing results.
+    /// Avoid informing the GC about native allocations.
     /// </summary>
-    public struct NoOpAllocationTracker : INativeAllocationTracker
+    public readonly struct NoOpAllocationTracker : INativeAllocationTracker
     {
         public void Track(int count, long bytes) { }
     }

--- a/test/Apache.Arrow.Tests/NativeBufferTests.cs
+++ b/test/Apache.Arrow.Tests/NativeBufferTests.cs
@@ -158,7 +158,10 @@ namespace Apache.Arrow.Tests
             // Smoke test: just verify it doesn't throw.
             // We can't directly observe GC memory pressure, but we verify the
             // alloc/dealloc cycle completes without error.
+            // Test-only use of obsolete API.
+#pragma warning disable CS0618 // Type or member is obsolete
             var buf = new NativeBuffer<byte, MemoryPressureAllocationTracker>(1024);
+#pragma warning restore CS0618 // Type or member is obsolete
             buf.Span[0] = 0xFF;
             buf.Dispose();
         }


### PR DESCRIPTION
## What's Changed

According to [documentation](https://learn.microsoft.com/en-us/dotnet/api/system.gc.addmemorypressure?view=net-10.0#remarks) (see also https://github.com/dotnet/runtime/issues/33812#issuecomment-601733199):

> The [AddMemoryPressure](https://learn.microsoft.com/en-us/dotnet/api/system.gc.addmemorypressure?view=net-10.0) and [RemoveMemoryPressure](https://learn.microsoft.com/en-us/dotnet/api/system.gc.removememorypressure?view=net-10.0) methods improve performance only for types that exclusively depend on finalizers to release the unmanaged resources. It's not necessary to use these methods in types that follow the dispose pattern, where finalizers are used to clean up unmanaged resources only in the event that a consumer of the type forgets to call `Dispose`. […]

None of the uses of these methods by Arrow satisfies the above criterion. Consequently, this PR removes them, with the exception of `MemoryPressureAllocationTracker` whose public API contract is to call these methods, and which got obsoleted by this PR.

Closes #50
Closes #261