### PR TITLE
Support IPC Message custom_metadata in ArrowStreamWriter and ArrowStreamReader (rebased continuation of #283)

### DIFF
--- a/src/Apache.Arrow.Flight/Internal/FlightDataStream.cs
+++ b/src/Apache.Arrow.Flight/Internal/FlightDataStream.cs
@@ -91,11 +91,11 @@ namespace Apache.Arrow.Flight.Internal
             await _clientStreamWriter.WriteAsync(_currentFlightData).ConfigureAwait(false);
         }
 
-        private protected override ValueTask<long> WriteMessageAsync<T>(MessageHeader headerType, Offset<T> headerOffset, int bodyLength, CancellationToken cancellationToken)
+        private protected override ValueTask<long> WriteMessageAsync<T>(MessageHeader headerType, Offset<T> headerOffset, int bodyLength, VectorOffset customMetadataOffset, CancellationToken cancellationToken)
         {
             Offset<Flatbuf.Message> messageOffset = Flatbuf.Message.CreateMessage(
                 Builder, CurrentMetadataVersion, headerType, headerOffset.Value,
-                bodyLength);
+                bodyLength, customMetadataOffset);
 
             Builder.Finish(messageOffset.Value);
 

--- a/src/Apache.Arrow/Ipc/ArrowReaderImplementation.cs
+++ b/src/Apache.Arrow/Ipc/ArrowReaderImplementation.cs
@@ -81,6 +81,11 @@ namespace Apache.Arrow.Ipc
         public abstract ValueTask<RecordBatch> ReadNextRecordBatchAsync(CancellationToken cancellationToken);
         public abstract RecordBatch ReadNextRecordBatch();
 
+        /// <summary>
+        /// Custom metadata from the most recently read RecordBatch Message, if any.
+        /// </summary>
+        internal IReadOnlyDictionary<string, string> LastBatchCustomMetadata { get; private protected set; }
+
         internal static T ReadMessage<T>(ByteBuffer bb)
             where T : struct, IFlatbufferObject
         {
@@ -148,6 +153,7 @@ namespace Apache.Arrow.Ipc
                     }
 
                     List<IArrowArray> arrays = BuildArrays(message.Version, Schema, bodyByteBuffer, rb);
+                    LastBatchCustomMetadata = ReadMessageCustomMetadata(message);
                     return new RecordBatch(Schema, memoryOwner, arrays, (int)rb.Length);
                 default:
                     // NOTE: Skip unsupported message type
@@ -156,6 +162,23 @@ namespace Apache.Arrow.Ipc
             }
 
             return null;
+        }
+
+        private static IReadOnlyDictionary<string, string> ReadMessageCustomMetadata(Flatbuf.Message message)
+        {
+            int count = message.CustomMetadataLength;
+            if (count == 0)
+                return null;
+
+            var result = new Dictionary<string, string>(count);
+            for (int i = 0; i < count; i++)
+            {
+                Flatbuf.KeyValue kv = message.CustomMetadata(i).GetValueOrDefault();
+                string key = kv.Key;
+                if (key != null)
+                    result[key] = kv.Value ?? "";
+            }
+            return result;
         }
 
         internal static ByteBuffer CreateByteBuffer(ReadOnlyMemory<byte> buffer)

--- a/src/Apache.Arrow/Ipc/ArrowStreamReader.cs
+++ b/src/Apache.Arrow/Ipc/ArrowStreamReader.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -151,5 +152,12 @@ namespace Apache.Arrow.Ipc
         {
             return _implementation.ReadNextRecordBatch();
         }
+
+        /// <summary>
+        /// Custom metadata from the most recently read RecordBatch Message.
+        /// Updated after each call to ReadNextRecordBatch/ReadNextRecordBatchAsync.
+        /// Returns null if the last batch had no custom metadata.
+        /// </summary>
+        public IReadOnlyDictionary<string, string> LastBatchCustomMetadata => _implementation.LastBatchCustomMetadata;
     }
 }

--- a/src/Apache.Arrow/Ipc/ArrowStreamReader.cs
+++ b/src/Apache.Arrow/Ipc/ArrowStreamReader.cs
@@ -155,8 +155,10 @@ namespace Apache.Arrow.Ipc
 
         /// <summary>
         /// Custom metadata from the most recently read RecordBatch Message.
-        /// Updated after each call to ReadNextRecordBatch/ReadNextRecordBatchAsync.
-        /// Returns null if the last batch had no custom metadata.
+        /// Set whenever ReadNextRecordBatch/ReadNextRecordBatchAsync successfully reads a
+        /// RecordBatch message; left unchanged when a call returns null (e.g. at the end of
+        /// the stream), so it continues to reflect the last RecordBatch that was read.
+        /// Returns null if that batch had no custom metadata.
         /// </summary>
         public IReadOnlyDictionary<string, string> LastBatchCustomMetadata => _implementation.LastBatchCustomMetadata;
     }

--- a/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
+++ b/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
@@ -807,6 +807,11 @@ namespace Apache.Arrow.Ipc
 
         private protected void WriteRecordBatchInternal(RecordBatch recordBatch)
         {
+            WriteRecordBatchInternal(recordBatch, customMetadata: null);
+        }
+
+        private protected void WriteRecordBatchInternal(RecordBatch recordBatch, IReadOnlyDictionary<string, string> customMetadata)
+        {
             // TODO: Truncate buffers with extraneous padding / unused capacity
 
             if (!HasWrittenSchema)
@@ -829,6 +834,14 @@ namespace Apache.Arrow.Ipc
 
             VectorOffset buffersVectorOffset = Builder.EndVector();
 
+            // Build custom metadata for the Message if provided
+            VectorOffset customMetadataVectorOffset = default;
+            if (customMetadata != null && customMetadata.Count > 0)
+            {
+                Offset<Flatbuf.KeyValue>[] metadataOffsets = GetMetadataOffsets(customMetadata);
+                customMetadataVectorOffset = Flatbuf.Message.CreateCustomMetadataVector(Builder, metadataOffsets);
+            }
+
             // Serialize record batch
 
             StartingWritingRecordBatch();
@@ -840,14 +853,21 @@ namespace Apache.Arrow.Ipc
                 variadicCountsOffset);
 
             long metadataLength = WriteMessage(Flatbuf.MessageHeader.RecordBatch,
-                recordBatchOffset, recordBatchBuilder.TotalLength);
+                recordBatchOffset, recordBatchBuilder.TotalLength, customMetadataVectorOffset);
 
             long bufferLength = WriteBufferData(recordBatchBuilder.Buffers);
 
             FinishedWritingRecordBatch(bufferLength, metadataLength);
         }
 
+        private protected Task WriteRecordBatchInternalAsync(RecordBatch recordBatch,
+            CancellationToken cancellationToken = default)
+        {
+            return WriteRecordBatchInternalAsync(recordBatch, customMetadata: null, cancellationToken);
+        }
+
         private protected async Task WriteRecordBatchInternalAsync(RecordBatch recordBatch,
+            IReadOnlyDictionary<string, string> customMetadata,
             CancellationToken cancellationToken = default)
         {
             if (!HasWrittenSchema)
@@ -870,6 +890,14 @@ namespace Apache.Arrow.Ipc
 
             VectorOffset buffersVectorOffset = Builder.EndVector();
 
+            // Build custom metadata for the Message if provided
+            VectorOffset customMetadataVectorOffset = default;
+            if (customMetadata != null && customMetadata.Count > 0)
+            {
+                Offset<Flatbuf.KeyValue>[] metadataOffsets = GetMetadataOffsets(customMetadata);
+                customMetadataVectorOffset = Flatbuf.Message.CreateCustomMetadataVector(Builder, metadataOffsets);
+            }
+
             // Serialize record batch
 
             StartingWritingRecordBatch();
@@ -882,6 +910,7 @@ namespace Apache.Arrow.Ipc
 
             long metadataLength = await WriteMessageAsync(Flatbuf.MessageHeader.RecordBatch,
                 recordBatchOffset, recordBatchBuilder.TotalLength,
+                customMetadataVectorOffset,
                 cancellationToken).ConfigureAwait(false);
 
             long bufferLength = await WriteBufferDataAsync(recordBatchBuilder.Buffers, cancellationToken).ConfigureAwait(false);
@@ -1132,9 +1161,19 @@ namespace Apache.Arrow.Ipc
             WriteRecordBatchInternal(recordBatch);
         }
 
+        public virtual void WriteRecordBatch(RecordBatch recordBatch, IReadOnlyDictionary<string, string> customMetadata)
+        {
+            WriteRecordBatchInternal(recordBatch, customMetadata);
+        }
+
         public virtual Task WriteRecordBatchAsync(RecordBatch recordBatch, CancellationToken cancellationToken = default)
         {
             return WriteRecordBatchInternalAsync(recordBatch, cancellationToken);
+        }
+
+        public virtual Task WriteRecordBatchAsync(RecordBatch recordBatch, IReadOnlyDictionary<string, string> customMetadata, CancellationToken cancellationToken = default)
+        {
+            return WriteRecordBatchInternalAsync(recordBatch, customMetadata, cancellationToken);
         }
 
         public void WriteStart()
@@ -1347,12 +1386,13 @@ namespace Apache.Arrow.Ipc
         /// The number of bytes written to the stream.
         /// </returns>
         private protected long WriteMessage<T>(
-            Flatbuf.MessageHeader headerType, Offset<T> headerOffset, int bodyLength)
+            Flatbuf.MessageHeader headerType, Offset<T> headerOffset, int bodyLength,
+            VectorOffset customMetadataOffset = default)
             where T : struct
         {
             Offset<Flatbuf.Message> messageOffset = Flatbuf.Message.CreateMessage(
                 Builder, CurrentMetadataVersion, headerType, headerOffset.Value,
-                bodyLength);
+                bodyLength, customMetadataOffset);
 
             Builder.Finish(messageOffset.Value);
 
@@ -1376,14 +1416,23 @@ namespace Apache.Arrow.Ipc
         /// <returns>
         /// The number of bytes written to the stream.
         /// </returns>
+        private protected virtual ValueTask<long> WriteMessageAsync<T>(
+            Flatbuf.MessageHeader headerType, Offset<T> headerOffset, int bodyLength,
+            CancellationToken cancellationToken)
+            where T : struct
+        {
+            return WriteMessageAsync(headerType, headerOffset, bodyLength, default, cancellationToken);
+        }
+
         private protected virtual async ValueTask<long> WriteMessageAsync<T>(
             Flatbuf.MessageHeader headerType, Offset<T> headerOffset, int bodyLength,
+            VectorOffset customMetadataOffset,
             CancellationToken cancellationToken)
             where T : struct
         {
             Offset<Flatbuf.Message> messageOffset = Flatbuf.Message.CreateMessage(
                 Builder, CurrentMetadataVersion, headerType, headerOffset.Value,
-                bodyLength);
+                bodyLength, customMetadataOffset);
 
             Builder.Finish(messageOffset.Value);
 

--- a/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
+++ b/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
@@ -838,6 +838,7 @@ namespace Apache.Arrow.Ipc
             VectorOffset customMetadataVectorOffset = default;
             if (customMetadata != null && customMetadata.Count > 0)
             {
+                ValidateCustomMetadata(customMetadata);
                 Offset<Flatbuf.KeyValue>[] metadataOffsets = GetMetadataOffsets(customMetadata);
                 customMetadataVectorOffset = Flatbuf.Message.CreateCustomMetadataVector(Builder, metadataOffsets);
             }
@@ -894,6 +895,7 @@ namespace Apache.Arrow.Ipc
             VectorOffset customMetadataVectorOffset = default;
             if (customMetadata != null && customMetadata.Count > 0)
             {
+                ValidateCustomMetadata(customMetadata);
                 Offset<Flatbuf.KeyValue>[] metadataOffsets = GetMetadataOffsets(customMetadata);
                 customMetadataVectorOffset = Flatbuf.Message.CreateCustomMetadataVector(Builder, metadataOffsets);
             }
@@ -1328,6 +1330,25 @@ namespace Apache.Arrow.Ipc
 
             Offset<Flatbuf.Int> indexOffset = Flatbuf.Int.CreateInt(Builder, indexType.BitWidth, indexType.IsSigned);
             return Flatbuf.DictionaryEncoding.CreateDictionaryEncoding(Builder, id, indexOffset, dicType.Ordered);
+        }
+
+        /// <summary>
+        /// Validates that a caller-supplied custom metadata dictionary contains no null keys or values,
+        /// so that failures are reported clearly rather than as an opaque exception from the FlatBuffer builder.
+        /// </summary>
+        private static void ValidateCustomMetadata(IReadOnlyDictionary<string, string> customMetadata)
+        {
+            foreach (KeyValuePair<string, string> metadatum in customMetadata)
+            {
+                if (metadatum.Key == null)
+                {
+                    throw new ArgumentException("Custom metadata must not contain null keys.", nameof(customMetadata));
+                }
+                if (metadatum.Value == null)
+                {
+                    throw new ArgumentException($"Custom metadata value for key '{metadatum.Key}' must not be null.", nameof(customMetadata));
+                }
+            }
         }
 
         private Offset<Flatbuf.KeyValue>[] GetMetadataOffsets(IReadOnlyDictionary<string, string> metadata)

--- a/test/Apache.Arrow.Tests/ArrowStreamWriterTests.cs
+++ b/test/Apache.Arrow.Tests/ArrowStreamWriterTests.cs
@@ -736,5 +736,164 @@ namespace Apache.Arrow.Tests
                 Assert.True(allocator.Statistics.Allocations > 0);
             Assert.Equal(0, allocator.Rented);
         }
+
+        [Fact]
+        public void WriteCustomMetadata_RoundTrips()
+        {
+            RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 10);
+            var customMetadata = new Dictionary<string, string>
+            {
+                ["rpc.method"] = "add",
+                ["rpc.version"] = "1",
+                ["request_id"] = "abc-123",
+            };
+
+            using var stream = new MemoryStream();
+            using (var writer = new ArrowStreamWriter(stream, originalBatch.Schema, leaveOpen: true))
+            {
+                writer.WriteRecordBatch(originalBatch, customMetadata);
+                writer.WriteEnd();
+            }
+
+            stream.Position = 0;
+
+            using var reader = new ArrowStreamReader(stream);
+            RecordBatch readBatch = reader.ReadNextRecordBatch();
+            Assert.NotNull(readBatch);
+            ArrowReaderVerifier.CompareBatches(originalBatch, readBatch);
+
+            var readMetadata = reader.LastBatchCustomMetadata;
+            Assert.NotNull(readMetadata);
+            Assert.Equal(3, readMetadata.Count);
+            Assert.Equal("add", readMetadata["rpc.method"]);
+            Assert.Equal("1", readMetadata["rpc.version"]);
+            Assert.Equal("abc-123", readMetadata["request_id"]);
+        }
+
+        [Fact]
+        public async Task WriteCustomMetadataAsync_RoundTrips()
+        {
+            RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 10);
+            var customMetadata = new Dictionary<string, string>
+            {
+                ["key1"] = "value1",
+                ["key2"] = "value2",
+            };
+
+            using var stream = new MemoryStream();
+            using (var writer = new ArrowStreamWriter(stream, originalBatch.Schema, leaveOpen: true))
+            {
+                await writer.WriteRecordBatchAsync(originalBatch, customMetadata);
+                await writer.WriteEndAsync();
+            }
+
+            stream.Position = 0;
+
+            using var reader = new ArrowStreamReader(stream);
+            RecordBatch readBatch = reader.ReadNextRecordBatch();
+            Assert.NotNull(readBatch);
+            ArrowReaderVerifier.CompareBatches(originalBatch, readBatch);
+
+            Assert.NotNull(reader.LastBatchCustomMetadata);
+            Assert.Equal("value1", reader.LastBatchCustomMetadata["key1"]);
+            Assert.Equal("value2", reader.LastBatchCustomMetadata["key2"]);
+        }
+
+        [Fact]
+        public void WriteCustomMetadata_MultipleBatches_EachHasOwnMetadata()
+        {
+            RecordBatch batch = TestData.CreateSampleRecordBatch(length: 5);
+            var meta1 = new Dictionary<string, string> { ["batch"] = "first" };
+            var meta2 = new Dictionary<string, string> { ["batch"] = "second", ["extra"] = "data" };
+
+            using var stream = new MemoryStream();
+            using (var writer = new ArrowStreamWriter(stream, batch.Schema, leaveOpen: true))
+            {
+                writer.WriteRecordBatch(batch, meta1);
+                writer.WriteRecordBatch(batch, meta2);
+                writer.WriteEnd();
+            }
+
+            stream.Position = 0;
+
+            using var reader = new ArrowStreamReader(stream);
+
+            reader.ReadNextRecordBatch();
+            Assert.NotNull(reader.LastBatchCustomMetadata);
+            Assert.Single(reader.LastBatchCustomMetadata);
+            Assert.Equal("first", reader.LastBatchCustomMetadata["batch"]);
+
+            reader.ReadNextRecordBatch();
+            Assert.NotNull(reader.LastBatchCustomMetadata);
+            Assert.Equal(2, reader.LastBatchCustomMetadata.Count);
+            Assert.Equal("second", reader.LastBatchCustomMetadata["batch"]);
+            Assert.Equal("data", reader.LastBatchCustomMetadata["extra"]);
+        }
+
+        [Fact]
+        public void WriteWithoutCustomMetadata_LastBatchCustomMetadataIsNull()
+        {
+            RecordBatch batch = TestData.CreateSampleRecordBatch(length: 5);
+
+            using var stream = new MemoryStream();
+            using (var writer = new ArrowStreamWriter(stream, batch.Schema, leaveOpen: true))
+            {
+                writer.WriteRecordBatch(batch);
+                writer.WriteEnd();
+            }
+
+            stream.Position = 0;
+
+            using var reader = new ArrowStreamReader(stream);
+            reader.ReadNextRecordBatch();
+            Assert.Null(reader.LastBatchCustomMetadata);
+        }
+
+        [Fact]
+        public void WriteCustomMetadata_MixedBatches_WithAndWithoutMetadata()
+        {
+            RecordBatch batch = TestData.CreateSampleRecordBatch(length: 5);
+            var meta = new Dictionary<string, string> { ["key"] = "value" };
+
+            using var stream = new MemoryStream();
+            using (var writer = new ArrowStreamWriter(stream, batch.Schema, leaveOpen: true))
+            {
+                writer.WriteRecordBatch(batch, meta);
+                writer.WriteRecordBatch(batch); // no metadata
+                writer.WriteEnd();
+            }
+
+            stream.Position = 0;
+
+            using var reader = new ArrowStreamReader(stream);
+
+            reader.ReadNextRecordBatch();
+            Assert.NotNull(reader.LastBatchCustomMetadata);
+            Assert.Equal("value", reader.LastBatchCustomMetadata["key"]);
+
+            reader.ReadNextRecordBatch();
+            Assert.Null(reader.LastBatchCustomMetadata);
+        }
+
+        [Fact]
+        public void WriteCustomMetadata_EmptyValues_RoundTrips()
+        {
+            RecordBatch batch = TestData.CreateSampleRecordBatch(length: 5);
+            var meta = new Dictionary<string, string> { ["empty"] = "" };
+
+            using var stream = new MemoryStream();
+            using (var writer = new ArrowStreamWriter(stream, batch.Schema, leaveOpen: true))
+            {
+                writer.WriteRecordBatch(batch, meta);
+                writer.WriteEnd();
+            }
+
+            stream.Position = 0;
+
+            using var reader = new ArrowStreamReader(stream);
+            reader.ReadNextRecordBatch();
+            Assert.NotNull(reader.LastBatchCustomMetadata);
+            Assert.Equal("", reader.LastBatchCustomMetadata["empty"]);
+        }
     }
 }

--- a/test/Apache.Arrow.Tests/CustomMetadataPythonTests.cs
+++ b/test/Apache.Arrow.Tests/CustomMetadataPythonTests.cs
@@ -1,0 +1,183 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Apache.Arrow.Ipc;
+using Python.Runtime;
+using Xunit;
+
+namespace Apache.Arrow.Tests
+{
+
+    // -------------------------------------------------------------------
+    // Cross-language Python tests for custom_metadata
+    // -------------------------------------------------------------------
+
+    public class CustomMetadataPythonTests : IClassFixture<CustomMetadataPythonTests.PythonNet>
+    {
+        public class PythonNet : IDisposable
+        {
+            public bool Initialized { get; }
+
+            public bool VersionMismatch { get; }
+
+            public PythonNet()
+            {
+                bool pythonSet = Environment.GetEnvironmentVariable("PYTHONNET_PYDLL") != null;
+                if (!pythonSet)
+                {
+                    Initialized = false;
+                    return;
+                }
+
+                try
+                {
+                    PythonEngine.Initialize();
+                }
+                catch (NotSupportedException e) when (e.Message.Contains("Python ABI ") && e.Message.Contains("not supported"))
+                {
+                    Initialized = false;
+                    VersionMismatch = true;
+                    return;
+                }
+
+                if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows) &&
+                    PythonEngine.PythonPath.IndexOf("dlls", StringComparison.OrdinalIgnoreCase) < 0)
+                {
+                    dynamic sys = Py.Import("sys");
+                    sys.path.append(Path.Combine(Path.GetDirectoryName(Environment.GetEnvironmentVariable("PYTHONNET_PYDLL")), "DLLs"));
+                }
+
+                Initialized = true;
+            }
+
+            public void Dispose()
+            {
+                PythonEngine.Shutdown();
+            }
+        }
+
+        public CustomMetadataPythonTests(PythonNet pythonNet)
+        {
+            if (!pythonNet.Initialized)
+            {
+                var errorReason = pythonNet.VersionMismatch ? "Python version is incompatible with PythonNet" : "PYTHONNET_PYDLL not set";
+
+                bool inCIJob = Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true";
+                bool inVerificationJob = Environment.GetEnvironmentVariable("TEST_CSHARP") == "1";
+
+                Skip.If(inVerificationJob || !inCIJob, $"{errorReason}; skipping custom metadata Python tests.");
+
+                throw new Exception($"{errorReason}; cannot run custom metadata Python tests.");
+            }
+        }
+
+        // -------------------------------------------------------------------
+        // C# writes IPC with custom_metadata → Python reads
+        // -------------------------------------------------------------------
+
+        [SkippableFact]
+        public void ExportCustomMetadata_PythonReads()
+        {
+            RecordBatch batch = TestData.CreateSampleRecordBatch(length: 5);
+            var batchMetadata = new Dictionary<string, string>
+            {
+                ["rpc.method"] = "greet",
+                ["request_id"] = "abc-123",
+                ["custom_key"] = "custom_value",
+            };
+
+            // Serialize to IPC stream with custom batch metadata
+            byte[] ipcBytes;
+            using (var ms = new MemoryStream())
+            {
+                using (var writer = new ArrowStreamWriter(ms, batch.Schema, leaveOpen: true))
+                {
+                    writer.WriteRecordBatch(batch, batchMetadata);
+                    writer.WriteEnd();
+                }
+                ipcBytes = ms.ToArray();
+            }
+
+            // Python reads and verifies custom_metadata
+            using (Py.GIL())
+            {
+                dynamic pa = Py.Import("pyarrow");
+                dynamic reader = pa.ipc.open_stream(pa.BufferReader(ipcBytes.ToPython()));
+
+                PyObject result = reader.read_next_batch_with_custom_metadata();
+                dynamic pyBatch = result[0];
+                dynamic customMeta = result[1];
+
+                // Verify batch data round-tripped
+                Assert.Equal(5, (int)pyBatch.num_rows);
+
+                // Verify custom_metadata (pyarrow returns bytes — decode to str)
+                Assert.Equal("greet", (string)customMeta["rpc.method"].decode());
+                Assert.Equal("abc-123", (string)customMeta["request_id"].decode());
+                Assert.Equal("custom_value", (string)customMeta["custom_key"].decode());
+            }
+        }
+
+        // -------------------------------------------------------------------
+        // Python writes IPC with custom_metadata → C# reads
+        // -------------------------------------------------------------------
+
+        [SkippableFact]
+        public void ImportCustomMetadata_PythonWrites()
+        {
+            byte[] ipcBytes;
+
+            // Python creates a batch with custom_metadata and serializes to IPC
+            using (Py.GIL())
+            {
+                dynamic pa = Py.Import("pyarrow");
+                dynamic io = Py.Import("io");
+
+                dynamic pyBatch = pa.record_batch(new PyList(new PyObject[]
+                {
+                    pa.array(new int[] { 1, 2, 3, 4, 5 }),
+                }), new[] { "x" });
+
+                dynamic buf = io.BytesIO();
+                dynamic writer = pa.ipc.new_stream(buf, pyBatch.schema);
+                dynamic customMeta = pa.KeyValueMetadata(new PyDict
+                {
+                    ["origin"] = "python".ToPython(),
+                    ["version"] = "2".ToPython(),
+                });
+                writer.write_batch(pyBatch, custom_metadata: customMeta);
+                writer.close();
+
+                ipcBytes = ((PyObject)buf.getvalue()).As<byte[]>();
+            }
+
+            // C# reads and verifies custom_metadata
+            using var ms = new MemoryStream(ipcBytes);
+            using var reader = new ArrowStreamReader(ms);
+
+            RecordBatch batch = reader.ReadNextRecordBatch();
+            Assert.NotNull(batch);
+            Assert.Equal(5, batch.Length);
+
+            var metadata = reader.LastBatchCustomMetadata;
+            Assert.NotNull(metadata);
+            Assert.Equal("python", metadata["origin"]);
+            Assert.Equal("2", metadata["version"]);
+        }
+    }
+}

--- a/test/Apache.Arrow.Tests/CustomMetadataPythonTests.cs
+++ b/test/Apache.Arrow.Tests/CustomMetadataPythonTests.cs
@@ -27,63 +27,12 @@ namespace Apache.Arrow.Tests
     // Cross-language Python tests for custom_metadata
     // -------------------------------------------------------------------
 
-    public class CustomMetadataPythonTests : IClassFixture<CustomMetadataPythonTests.PythonNet>
+    [Collection("PythonNet")]
+    public class CustomMetadataPythonTests
     {
-        public class PythonNet : IDisposable
+        public CustomMetadataPythonTests(PythonNetFixture pythonNet)
         {
-            public bool Initialized { get; }
-
-            public bool VersionMismatch { get; }
-
-            public PythonNet()
-            {
-                bool pythonSet = Environment.GetEnvironmentVariable("PYTHONNET_PYDLL") != null;
-                if (!pythonSet)
-                {
-                    Initialized = false;
-                    return;
-                }
-
-                try
-                {
-                    PythonEngine.Initialize();
-                }
-                catch (NotSupportedException e) when (e.Message.Contains("Python ABI ") && e.Message.Contains("not supported"))
-                {
-                    Initialized = false;
-                    VersionMismatch = true;
-                    return;
-                }
-
-                if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows) &&
-                    PythonEngine.PythonPath.IndexOf("dlls", StringComparison.OrdinalIgnoreCase) < 0)
-                {
-                    dynamic sys = Py.Import("sys");
-                    sys.path.append(Path.Combine(Path.GetDirectoryName(Environment.GetEnvironmentVariable("PYTHONNET_PYDLL")), "DLLs"));
-                }
-
-                Initialized = true;
-            }
-
-            public void Dispose()
-            {
-                PythonEngine.Shutdown();
-            }
-        }
-
-        public CustomMetadataPythonTests(PythonNet pythonNet)
-        {
-            if (!pythonNet.Initialized)
-            {
-                var errorReason = pythonNet.VersionMismatch ? "Python version is incompatible with PythonNet" : "PYTHONNET_PYDLL not set";
-
-                bool inCIJob = Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true";
-                bool inVerificationJob = Environment.GetEnvironmentVariable("TEST_CSHARP") == "1";
-
-                Skip.If(inVerificationJob || !inCIJob, $"{errorReason}; skipping custom metadata Python tests.");
-
-                throw new Exception($"{errorReason}; cannot run custom metadata Python tests.");
-            }
+            pythonNet.EnsureInitialized();
         }
 
         // -------------------------------------------------------------------


### PR DESCRIPTION
Continuation of #283, rebased onto current `main` (the original PR had drifted ~76 commits behind and could no longer be evaluated for mergeability).

Original work by @cmettler in #283, closing #282. This PR carries those three commits forward unchanged (same authorship) on top of the current `main`, which in the interim gained unrelated IPC changes (RunEndEncodedArray, LargeListView, IPC buffer bounds validation, etc.) that touch the same files.

## What this adds
- `ArrowStreamReader.LastBatchCustomMetadata`: exposes the IPC `Message.custom_metadata` key/value pairs for the most recently read batch — the read-side counterpart to pyarrow's `read_next_batch_with_custom_metadata()`.
- `ArrowStreamWriter.WriteRecordBatch(batch, customMetadata)` (and async counterpart): lets callers attach per-message `custom_metadata` when writing IPC streams, matching pyarrow's `write_batch(batch, custom_metadata)`.
- Cross-language round-trip tests via pythonnet + pyarrow (skipped unless `PYTHONNET_PYDLL` is set, consistent with the existing `CDataSchemaPythonTest` pattern in this repo).

## Verification on this rebase
- `dotnet build Apache.Arrow.sln` — succeeds, 0 warnings/errors.
- `dotnet test test/Apache.Arrow.Tests/Apache.Arrow.Tests.csproj` — full suite: 1876 passed, 30 skipped (pre-existing Python-dependent tests, unrelated to this change), 0 failed.
- `dotnet format Apache.Arrow.sln --exclude src/Apache.Arrow/Flatbuf/FlatBuffers/ --verify-no-changes` — clean.

Closes https://github.com/apache/arrow-dotnet/issues/282
Supersedes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)
