### PR TITLE
feat: Support IPC Message custom_metadata in ArrowStreamWriter and ArrowStreamReader

### DIFF
--- a/src/Apache.Arrow.Flight/Internal/FlightDataStream.cs
+++ b/src/Apache.Arrow.Flight/Internal/FlightDataStream.cs
@@ -55,7 +55,7 @@ namespace Apache.Arrow.Flight.Internal
 
             var offset = SerializeSchema(Schema);
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
-            await WriteMessageAsync(MessageHeader.Schema, offset, 0, cancellationTokenSource.Token).ConfigureAwait(false);
+            await WriteMessageAsync(MessageHeader.Schema, offset, 0, default, cancellationTokenSource.Token).ConfigureAwait(false);
             await _clientStreamWriter.WriteAsync(_currentFlightData).ConfigureAwait(false);
             HasWrittenSchema = true;
         }
@@ -81,7 +81,7 @@ namespace Apache.Arrow.Flight.Internal
                 _currentFlightData.AppMetadata = applicationMetadata;
             }
 
-            await WriteRecordBatchInternalAsync(recordBatch).ConfigureAwait(false);
+            await WriteRecordBatchInternalAsync(recordBatch, customMetadata: null).ConfigureAwait(false);
 
             //Reset stream position
             this.BaseStream.Position = 0;

--- a/src/Apache.Arrow.Flight/Internal/FlightDataStream.cs
+++ b/src/Apache.Arrow.Flight/Internal/FlightDataStream.cs
@@ -91,11 +91,11 @@ namespace Apache.Arrow.Flight.Internal
             await _clientStreamWriter.WriteAsync(_currentFlightData).ConfigureAwait(false);
         }
 
-        private protected override ValueTask<long> WriteMessageAsync<T>(MessageHeader headerType, Offset<T> headerOffset, int bodyLength, CancellationToken cancellationToken)
+        private protected override ValueTask<long> WriteMessageAsync<T>(MessageHeader headerType, Offset<T> headerOffset, int bodyLength, VectorOffset customMetadataOffset, CancellationToken cancellationToken)
         {
             Offset<Flatbuf.Message> messageOffset = Flatbuf.Message.CreateMessage(
                 Builder, CurrentMetadataVersion, headerType, headerOffset.Value,
-                bodyLength);
+                bodyLength, customMetadataOffset);
 
             Builder.Finish(messageOffset.Value);
 

--- a/src/Apache.Arrow/Ipc/ArrowFileReader.cs
+++ b/src/Apache.Arrow/Ipc/ArrowFileReader.cs
@@ -85,5 +85,16 @@ namespace Apache.Arrow.Ipc
         {
             return Implementation.ReadRecordBatchAsync(index, cancellationToken);
         }
+
+        /// <summary>
+        /// Reads the record batch at the given index together with the custom metadata on its
+        /// IPC Message, which is null if the message carried none.
+        /// </summary>
+        public async ValueTask<RecordBatchWithMetadata> ReadRecordBatchWithCustomMetadataAsync(int index, CancellationToken cancellationToken = default)
+        {
+            RecordBatch batch = await Implementation.ReadRecordBatchAsync(index, cancellationToken).ConfigureAwait(false);
+
+            return batch == null ? default : new RecordBatchWithMetadata(batch, Implementation.LastBatchCustomMetadata);
+        }
     }
 }

--- a/src/Apache.Arrow/Ipc/ArrowFileWriter.cs
+++ b/src/Apache.Arrow/Ipc/ArrowFileWriter.cs
@@ -66,27 +66,6 @@ namespace Apache.Arrow.Ipc
             RecordBatchBlocks = new List<Block>();
         }
 
-        public override void WriteRecordBatch(RecordBatch recordBatch)
-        {
-            // TODO: Compare record batch schema
-
-            WriteStart();
-
-            WriteRecordBatchInternal(recordBatch);
-        }
-
-        public override async Task WriteRecordBatchAsync(RecordBatch recordBatch, CancellationToken cancellationToken = default)
-        {
-            // TODO: Compare record batch schema
-
-            await WriteStartAsync(cancellationToken).ConfigureAwait(false);
-
-            cancellationToken.ThrowIfCancellationRequested();
-
-            await WriteRecordBatchInternalAsync(recordBatch, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
         private protected override void StartingWritingRecordBatch()
         {
             _currentRecordBatchOffset = BaseStream.Position;

--- a/src/Apache.Arrow/Ipc/ArrowReaderImplementation.cs
+++ b/src/Apache.Arrow/Ipc/ArrowReaderImplementation.cs
@@ -81,6 +81,11 @@ namespace Apache.Arrow.Ipc
         public abstract ValueTask<RecordBatch> ReadNextRecordBatchAsync(CancellationToken cancellationToken);
         public abstract RecordBatch ReadNextRecordBatch();
 
+        /// <summary>
+        /// Custom metadata from the most recently read RecordBatch Message, if any.
+        /// </summary>
+        internal IReadOnlyDictionary<string, string> LastBatchCustomMetadata { get; private protected set; }
+
         internal static T ReadMessage<T>(ByteBuffer bb)
             where T : struct, IFlatbufferObject
         {
@@ -148,6 +153,7 @@ namespace Apache.Arrow.Ipc
                     }
 
                     List<IArrowArray> arrays = BuildArrays(message.Version, Schema, bodyByteBuffer, rb);
+                    LastBatchCustomMetadata = ReadMessageCustomMetadata(message);
                     return new RecordBatch(Schema, memoryOwner, arrays, (int)rb.Length);
                 default:
                     // NOTE: Skip unsupported message type
@@ -156,6 +162,23 @@ namespace Apache.Arrow.Ipc
             }
 
             return null;
+        }
+
+        private static IReadOnlyDictionary<string, string> ReadMessageCustomMetadata(Flatbuf.Message message)
+        {
+            int count = message.CustomMetadataLength;
+            if (count == 0)
+                return null;
+
+            var result = new Dictionary<string, string>(count);
+            for (int i = 0; i < count; i++)
+            {
+                Flatbuf.KeyValue kv = message.CustomMetadata(i).GetValueOrDefault();
+                string key = kv.Key;
+                if (key != null)
+                    result[key] = kv.Value ?? "";
+            }
+            return result;
         }
 
         internal static ByteBuffer CreateByteBuffer(ReadOnlyMemory<byte> buffer)

--- a/src/Apache.Arrow/Ipc/ArrowReaderImplementation.cs
+++ b/src/Apache.Arrow/Ipc/ArrowReaderImplementation.cs
@@ -166,19 +166,16 @@ namespace Apache.Arrow.Ipc
 
         private static IReadOnlyDictionary<string, string> ReadMessageCustomMetadata(Flatbuf.Message message)
         {
-            int count = message.CustomMetadataLength;
-            if (count == 0)
-                return null;
-
-            var result = new Dictionary<string, string>(count);
-            for (int i = 0; i < count; i++)
+            Dictionary<string, string> metadata = message.CustomMetadataLength > 0
+                ? new Dictionary<string, string>(message.CustomMetadataLength) : null;
+            for (int i = 0; i < message.CustomMetadataLength; i++)
             {
-                Flatbuf.KeyValue kv = message.CustomMetadata(i).GetValueOrDefault();
-                string key = kv.Key;
-                if (key != null)
-                    result[key] = kv.Value ?? "";
+                Flatbuf.KeyValue keyValue = message.CustomMetadata(i).GetValueOrDefault();
+
+                metadata[keyValue.Key] = keyValue.Value;
             }
-            return result;
+
+            return metadata;
         }
 
         internal static ByteBuffer CreateByteBuffer(ReadOnlyMemory<byte> buffer)

--- a/src/Apache.Arrow/Ipc/ArrowStreamReader.cs
+++ b/src/Apache.Arrow/Ipc/ArrowStreamReader.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -151,5 +152,12 @@ namespace Apache.Arrow.Ipc
         {
             return _implementation.ReadNextRecordBatch();
         }
+
+        /// <summary>
+        /// Custom metadata from the most recently read RecordBatch Message.
+        /// Updated after each call to ReadNextRecordBatch/ReadNextRecordBatchAsync.
+        /// Returns null if the last batch had no custom metadata.
+        /// </summary>
+        public IReadOnlyDictionary<string, string> LastBatchCustomMetadata => _implementation.LastBatchCustomMetadata;
     }
 }

--- a/src/Apache.Arrow/Ipc/ArrowStreamReader.cs
+++ b/src/Apache.Arrow/Ipc/ArrowStreamReader.cs
@@ -155,8 +155,10 @@ namespace Apache.Arrow.Ipc
 
         /// <summary>
         /// Custom metadata from the most recently read RecordBatch Message.
-        /// Updated after each call to ReadNextRecordBatch/ReadNextRecordBatchAsync.
-        /// Returns null if the last batch had no custom metadata.
+        /// Set whenever ReadNextRecordBatch/ReadNextRecordBatchAsync successfully reads a
+        /// RecordBatch message; left unchanged when a call returns null (e.g. at the end of
+        /// the stream), so it continues to reflect the last RecordBatch that was read.
+        /// Returns null if that batch had no custom metadata.
         /// </summary>
         public IReadOnlyDictionary<string, string> LastBatchCustomMetadata => _implementation.LastBatchCustomMetadata;
     }

--- a/src/Apache.Arrow/Ipc/ArrowStreamReader.cs
+++ b/src/Apache.Arrow/Ipc/ArrowStreamReader.cs
@@ -154,12 +154,37 @@ namespace Apache.Arrow.Ipc
         }
 
         /// <summary>
-        /// Custom metadata from the most recently read RecordBatch Message.
-        /// Set whenever ReadNextRecordBatch/ReadNextRecordBatchAsync successfully reads a
-        /// RecordBatch message; left unchanged when a call returns null (e.g. at the end of
-        /// the stream), so it continues to reflect the last RecordBatch that was read.
-        /// Returns null if that batch had no custom metadata.
+        /// Reads the next record batch together with the custom metadata on its IPC Message,
+        /// the counterpart of <see cref="ArrowStreamWriter.WriteRecordBatch(RecordBatch, IReadOnlyDictionary{string, string})"/>.
         /// </summary>
-        public IReadOnlyDictionary<string, string> LastBatchCustomMetadata => _implementation.LastBatchCustomMetadata;
+        /// <returns>
+        /// The record batch and its custom metadata. At the end of the stream both
+        /// <see cref="RecordBatchWithMetadata.Batch"/> and
+        /// <see cref="RecordBatchWithMetadata.CustomMetadata"/> are null; the metadata is also
+        /// null for a batch whose message carried none.
+        /// </returns>
+        public async ValueTask<RecordBatchWithMetadata> ReadNextRecordBatchWithCustomMetadataAsync(CancellationToken cancellationToken = default)
+        {
+            RecordBatch batch = await _implementation.ReadNextRecordBatchAsync(cancellationToken).ConfigureAwait(false);
+
+            return batch == null ? default : new RecordBatchWithMetadata(batch, _implementation.LastBatchCustomMetadata);
+        }
+
+        /// <summary>
+        /// Reads the next record batch together with the custom metadata on its IPC Message,
+        /// the counterpart of <see cref="ArrowStreamWriter.WriteRecordBatch(RecordBatch, IReadOnlyDictionary{string, string})"/>.
+        /// </summary>
+        /// <returns>
+        /// The record batch and its custom metadata. At the end of the stream both
+        /// <see cref="RecordBatchWithMetadata.Batch"/> and
+        /// <see cref="RecordBatchWithMetadata.CustomMetadata"/> are null; the metadata is also
+        /// null for a batch whose message carried none.
+        /// </returns>
+        public RecordBatchWithMetadata ReadNextRecordBatchWithCustomMetadata()
+        {
+            RecordBatch batch = _implementation.ReadNextRecordBatch();
+
+            return batch == null ? default : new RecordBatchWithMetadata(batch, _implementation.LastBatchCustomMetadata);
+        }
     }
 }

--- a/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
+++ b/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
@@ -807,6 +807,11 @@ namespace Apache.Arrow.Ipc
 
         private protected void WriteRecordBatchInternal(RecordBatch recordBatch)
         {
+            WriteRecordBatchInternal(recordBatch, customMetadata: null);
+        }
+
+        private protected void WriteRecordBatchInternal(RecordBatch recordBatch, IReadOnlyDictionary<string, string> customMetadata)
+        {
             // TODO: Truncate buffers with extraneous padding / unused capacity
 
             if (!HasWrittenSchema)
@@ -829,6 +834,14 @@ namespace Apache.Arrow.Ipc
 
             VectorOffset buffersVectorOffset = Builder.EndVector();
 
+            // Build custom metadata for the Message if provided
+            VectorOffset customMetadataVectorOffset = default;
+            if (customMetadata != null && customMetadata.Count > 0)
+            {
+                Offset<Flatbuf.KeyValue>[] metadataOffsets = GetMetadataOffsets(customMetadata);
+                customMetadataVectorOffset = Flatbuf.Message.CreateCustomMetadataVector(Builder, metadataOffsets);
+            }
+
             // Serialize record batch
 
             StartingWritingRecordBatch();
@@ -840,14 +853,21 @@ namespace Apache.Arrow.Ipc
                 variadicCountsOffset);
 
             long metadataLength = WriteMessage(Flatbuf.MessageHeader.RecordBatch,
-                recordBatchOffset, recordBatchBuilder.TotalLength);
+                recordBatchOffset, recordBatchBuilder.TotalLength, customMetadataVectorOffset);
 
             long bufferLength = WriteBufferData(recordBatchBuilder.Buffers);
 
             FinishedWritingRecordBatch(bufferLength, metadataLength);
         }
 
+        private protected Task WriteRecordBatchInternalAsync(RecordBatch recordBatch,
+            CancellationToken cancellationToken = default)
+        {
+            return WriteRecordBatchInternalAsync(recordBatch, customMetadata: null, cancellationToken);
+        }
+
         private protected async Task WriteRecordBatchInternalAsync(RecordBatch recordBatch,
+            IReadOnlyDictionary<string, string> customMetadata,
             CancellationToken cancellationToken = default)
         {
             if (!HasWrittenSchema)
@@ -870,6 +890,14 @@ namespace Apache.Arrow.Ipc
 
             VectorOffset buffersVectorOffset = Builder.EndVector();
 
+            // Build custom metadata for the Message if provided
+            VectorOffset customMetadataVectorOffset = default;
+            if (customMetadata != null && customMetadata.Count > 0)
+            {
+                Offset<Flatbuf.KeyValue>[] metadataOffsets = GetMetadataOffsets(customMetadata);
+                customMetadataVectorOffset = Flatbuf.Message.CreateCustomMetadataVector(Builder, metadataOffsets);
+            }
+
             // Serialize record batch
 
             StartingWritingRecordBatch();
@@ -882,6 +910,7 @@ namespace Apache.Arrow.Ipc
 
             long metadataLength = await WriteMessageAsync(Flatbuf.MessageHeader.RecordBatch,
                 recordBatchOffset, recordBatchBuilder.TotalLength,
+                customMetadataVectorOffset,
                 cancellationToken).ConfigureAwait(false);
 
             long bufferLength = await WriteBufferDataAsync(recordBatchBuilder.Buffers, cancellationToken).ConfigureAwait(false);
@@ -1132,9 +1161,19 @@ namespace Apache.Arrow.Ipc
             WriteRecordBatchInternal(recordBatch);
         }
 
+        public virtual void WriteRecordBatch(RecordBatch recordBatch, IReadOnlyDictionary<string, string> customMetadata)
+        {
+            WriteRecordBatchInternal(recordBatch, customMetadata);
+        }
+
         public virtual Task WriteRecordBatchAsync(RecordBatch recordBatch, CancellationToken cancellationToken = default)
         {
             return WriteRecordBatchInternalAsync(recordBatch, cancellationToken);
+        }
+
+        public virtual Task WriteRecordBatchAsync(RecordBatch recordBatch, IReadOnlyDictionary<string, string> customMetadata, CancellationToken cancellationToken = default)
+        {
+            return WriteRecordBatchInternalAsync(recordBatch, customMetadata, cancellationToken);
         }
 
         public void WriteStart()
@@ -1347,12 +1386,13 @@ namespace Apache.Arrow.Ipc
         /// The number of bytes written to the stream.
         /// </returns>
         private protected long WriteMessage<T>(
-            Flatbuf.MessageHeader headerType, Offset<T> headerOffset, int bodyLength)
+            Flatbuf.MessageHeader headerType, Offset<T> headerOffset, int bodyLength,
+            VectorOffset customMetadataOffset = default)
             where T : struct
         {
             Offset<Flatbuf.Message> messageOffset = Flatbuf.Message.CreateMessage(
                 Builder, CurrentMetadataVersion, headerType, headerOffset.Value,
-                bodyLength);
+                bodyLength, customMetadataOffset);
 
             Builder.Finish(messageOffset.Value);
 
@@ -1376,14 +1416,23 @@ namespace Apache.Arrow.Ipc
         /// <returns>
         /// The number of bytes written to the stream.
         /// </returns>
+        private protected virtual ValueTask<long> WriteMessageAsync<T>(
+            Flatbuf.MessageHeader headerType, Offset<T> headerOffset, int bodyLength,
+            CancellationToken cancellationToken)
+            where T : struct
+        {
+            return WriteMessageAsync(headerType, headerOffset, bodyLength, default, cancellationToken);
+        }
+
         private protected virtual async ValueTask<long> WriteMessageAsync<T>(
             Flatbuf.MessageHeader headerType, Offset<T> headerOffset, int bodyLength,
+            VectorOffset customMetadataOffset,
             CancellationToken cancellationToken)
             where T : struct
         {
             Offset<Flatbuf.Message> messageOffset = Flatbuf.Message.CreateMessage(
                 Builder, CurrentMetadataVersion, headerType, headerOffset.Value,
-                bodyLength);
+                bodyLength, customMetadataOffset);
 
             Builder.Finish(messageOffset.Value);
 

--- a/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
+++ b/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
@@ -805,14 +805,17 @@ namespace Apache.Arrow.Ipc
                 Builder, compressionType, Flatbuf.BodyCompressionMethod.BUFFER);
         }
 
-        private protected void WriteRecordBatchInternal(RecordBatch recordBatch)
-        {
-            WriteRecordBatchInternal(recordBatch, customMetadata: null);
-        }
-
         private protected void WriteRecordBatchInternal(RecordBatch recordBatch, IReadOnlyDictionary<string, string> customMetadata)
         {
             // TODO: Truncate buffers with extraneous padding / unused capacity
+            // TODO: Compare record batch schema
+
+            ValidateCustomMetadata(customMetadata);
+
+            // Derived writers use WriteStartInternal to emit a preamble before any message
+            // (ArrowFileWriter writes the file magic there). Doing this here rather than in
+            // the public entry points means a new WriteRecordBatch overload cannot skip it.
+            WriteStart();
 
             if (!HasWrittenSchema)
             {
@@ -834,14 +837,7 @@ namespace Apache.Arrow.Ipc
 
             VectorOffset buffersVectorOffset = Builder.EndVector();
 
-            // Build custom metadata for the Message if provided
-            VectorOffset customMetadataVectorOffset = default;
-            if (customMetadata != null && customMetadata.Count > 0)
-            {
-                ValidateCustomMetadata(customMetadata);
-                Offset<Flatbuf.KeyValue>[] metadataOffsets = GetMetadataOffsets(customMetadata);
-                customMetadataVectorOffset = Flatbuf.Message.CreateCustomMetadataVector(Builder, metadataOffsets);
-            }
+            VectorOffset customMetadataVectorOffset = GetCustomMetadataOffset(customMetadata);
 
             // Serialize record batch
 
@@ -861,16 +857,17 @@ namespace Apache.Arrow.Ipc
             FinishedWritingRecordBatch(bufferLength, metadataLength);
         }
 
-        private protected Task WriteRecordBatchInternalAsync(RecordBatch recordBatch,
-            CancellationToken cancellationToken = default)
-        {
-            return WriteRecordBatchInternalAsync(recordBatch, customMetadata: null, cancellationToken);
-        }
-
         private protected async Task WriteRecordBatchInternalAsync(RecordBatch recordBatch,
             IReadOnlyDictionary<string, string> customMetadata,
             CancellationToken cancellationToken = default)
         {
+            // TODO: Compare record batch schema
+
+            ValidateCustomMetadata(customMetadata);
+
+            // See the comment in WriteRecordBatchInternal.
+            await WriteStartAsync(cancellationToken).ConfigureAwait(false);
+
             if (!HasWrittenSchema)
             {
                 await WriteSchemaAsync(Schema, cancellationToken).ConfigureAwait(false);
@@ -891,14 +888,7 @@ namespace Apache.Arrow.Ipc
 
             VectorOffset buffersVectorOffset = Builder.EndVector();
 
-            // Build custom metadata for the Message if provided
-            VectorOffset customMetadataVectorOffset = default;
-            if (customMetadata != null && customMetadata.Count > 0)
-            {
-                ValidateCustomMetadata(customMetadata);
-                Offset<Flatbuf.KeyValue>[] metadataOffsets = GetMetadataOffsets(customMetadata);
-                customMetadataVectorOffset = Flatbuf.Message.CreateCustomMetadataVector(Builder, metadataOffsets);
-            }
+            VectorOffset customMetadataVectorOffset = GetCustomMetadataOffset(customMetadata);
 
             // Serialize record batch
 
@@ -1090,7 +1080,7 @@ namespace Apache.Arrow.Ipc
             using var builder = recordBatchBuilder;
 
             long metadataLength = await WriteMessageAsync(Flatbuf.MessageHeader.DictionaryBatch,
-                dictionaryBatchOffset, recordBatchBuilder.TotalLength, cancellationToken).ConfigureAwait(false);
+                dictionaryBatchOffset, recordBatchBuilder.TotalLength, default, cancellationToken).ConfigureAwait(false);
 
             long bufferLength = await WriteBufferDataAsync(recordBatchBuilder.Buffers, cancellationToken).ConfigureAwait(false);
 
@@ -1160,7 +1150,7 @@ namespace Apache.Arrow.Ipc
 
         public virtual void WriteRecordBatch(RecordBatch recordBatch)
         {
-            WriteRecordBatchInternal(recordBatch);
+            WriteRecordBatchInternal(recordBatch, customMetadata: null);
         }
 
         public virtual void WriteRecordBatch(RecordBatch recordBatch, IReadOnlyDictionary<string, string> customMetadata)
@@ -1170,7 +1160,7 @@ namespace Apache.Arrow.Ipc
 
         public virtual Task WriteRecordBatchAsync(RecordBatch recordBatch, CancellationToken cancellationToken = default)
         {
-            return WriteRecordBatchInternalAsync(recordBatch, cancellationToken);
+            return WriteRecordBatchInternalAsync(recordBatch, customMetadata: null, cancellationToken);
         }
 
         public virtual Task WriteRecordBatchAsync(RecordBatch recordBatch, IReadOnlyDictionary<string, string> customMetadata, CancellationToken cancellationToken = default)
@@ -1333,11 +1323,31 @@ namespace Apache.Arrow.Ipc
         }
 
         /// <summary>
+        /// Builds the Message-level custom_metadata vector, or a default offset when there is none.
+        /// </summary>
+        private VectorOffset GetCustomMetadataOffset(IReadOnlyDictionary<string, string> customMetadata)
+        {
+            if (customMetadata == null || customMetadata.Count == 0)
+            {
+                return default;
+            }
+
+            Offset<Flatbuf.KeyValue>[] metadataOffsets = GetMetadataOffsets(customMetadata);
+            return Flatbuf.Message.CreateCustomMetadataVector(Builder, metadataOffsets);
+        }
+
+        /// <summary>
         /// Validates that a caller-supplied custom metadata dictionary contains no null keys or values,
-        /// so that failures are reported clearly rather than as an opaque exception from the FlatBuffer builder.
+        /// so that failures are reported before anything is written rather than as an opaque exception
+        /// from the FlatBuffer builder part-way through a message.
         /// </summary>
         private static void ValidateCustomMetadata(IReadOnlyDictionary<string, string> customMetadata)
         {
+            if (customMetadata == null)
+            {
+                return;
+            }
+
             foreach (KeyValuePair<string, string> metadatum in customMetadata)
             {
                 if (metadatum.Key == null)
@@ -1394,7 +1404,7 @@ namespace Apache.Arrow.Ipc
 
             // Build message
 
-            await WriteMessageAsync(Flatbuf.MessageHeader.Schema, schemaOffset, 0, cancellationToken)
+            await WriteMessageAsync(Flatbuf.MessageHeader.Schema, schemaOffset, 0, default, cancellationToken)
                 .ConfigureAwait(false);
 
             return schemaOffset;
@@ -1437,14 +1447,6 @@ namespace Apache.Arrow.Ipc
         /// <returns>
         /// The number of bytes written to the stream.
         /// </returns>
-        private protected virtual ValueTask<long> WriteMessageAsync<T>(
-            Flatbuf.MessageHeader headerType, Offset<T> headerOffset, int bodyLength,
-            CancellationToken cancellationToken)
-            where T : struct
-        {
-            return WriteMessageAsync(headerType, headerOffset, bodyLength, default, cancellationToken);
-        }
-
         private protected virtual async ValueTask<long> WriteMessageAsync<T>(
             Flatbuf.MessageHeader headerType, Offset<T> headerOffset, int bodyLength,
             VectorOffset customMetadataOffset,

--- a/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
+++ b/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
@@ -838,6 +838,7 @@ namespace Apache.Arrow.Ipc
             VectorOffset customMetadataVectorOffset = default;
             if (customMetadata != null && customMetadata.Count > 0)
             {
+                ValidateCustomMetadata(customMetadata);
                 Offset<Flatbuf.KeyValue>[] metadataOffsets = GetMetadataOffsets(customMetadata);
                 customMetadataVectorOffset = Flatbuf.Message.CreateCustomMetadataVector(Builder, metadataOffsets);
             }
@@ -894,6 +895,7 @@ namespace Apache.Arrow.Ipc
             VectorOffset customMetadataVectorOffset = default;
             if (customMetadata != null && customMetadata.Count > 0)
             {
+                ValidateCustomMetadata(customMetadata);
                 Offset<Flatbuf.KeyValue>[] metadataOffsets = GetMetadataOffsets(customMetadata);
                 customMetadataVectorOffset = Flatbuf.Message.CreateCustomMetadataVector(Builder, metadataOffsets);
             }
@@ -1328,6 +1330,25 @@ namespace Apache.Arrow.Ipc
 
             Offset<Flatbuf.Int> indexOffset = Flatbuf.Int.CreateInt(Builder, indexType.BitWidth, indexType.IsSigned);
             return Flatbuf.DictionaryEncoding.CreateDictionaryEncoding(Builder, id, indexOffset, dicType.Ordered);
+        }
+
+        /// <summary>
+        /// Validates that a caller-supplied custom metadata dictionary contains no null keys or values,
+        /// so that failures are reported clearly rather than as an opaque exception from the FlatBuffer builder.
+        /// </summary>
+        private static void ValidateCustomMetadata(IReadOnlyDictionary<string, string> customMetadata)
+        {
+            foreach (KeyValuePair<string, string> metadatum in customMetadata)
+            {
+                if (metadatum.Key == null)
+                {
+                    throw new ArgumentException("Custom metadata must not contain null keys.", nameof(customMetadata));
+                }
+                if (metadatum.Value == null)
+                {
+                    throw new ArgumentException($"Custom metadata value for key '{metadatum.Key}' must not be null.", nameof(customMetadata));
+                }
+            }
         }
 
         private Offset<Flatbuf.KeyValue>[] GetMetadataOffsets(IReadOnlyDictionary<string, string> metadata)

--- a/src/Apache.Arrow/Ipc/RecordBatchWithMetadata.cs
+++ b/src/Apache.Arrow/Ipc/RecordBatchWithMetadata.cs
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+
+namespace Apache.Arrow.Ipc
+{
+    /// <summary>
+    /// A record batch read from an Arrow IPC source, together with the custom metadata
+    /// carried on the IPC Message that held it.
+    /// </summary>
+    public readonly struct RecordBatchWithMetadata
+    {
+        public RecordBatchWithMetadata(RecordBatch batch, IReadOnlyDictionary<string, string> customMetadata)
+        {
+            Batch = batch;
+            CustomMetadata = customMetadata;
+        }
+
+        /// <summary>
+        /// The record batch that was read, or null at the end of the stream.
+        /// </summary>
+        public RecordBatch Batch { get; }
+
+        /// <summary>
+        /// The Message-level custom metadata accompanying <see cref="Batch"/>, or null if the
+        /// message carried none.
+        /// </summary>
+        public IReadOnlyDictionary<string, string> CustomMetadata { get; }
+
+        public void Deconstruct(out RecordBatch batch, out IReadOnlyDictionary<string, string> customMetadata)
+        {
+            batch = Batch;
+            customMetadata = CustomMetadata;
+        }
+    }
+}

--- a/test/Apache.Arrow.Tests/ArrowFileWriterTests.cs
+++ b/test/Apache.Arrow.Tests/ArrowFileWriterTests.cs
@@ -372,8 +372,14 @@ namespace Apache.Arrow.Tests
 
             stream.Position = 0;
             using var reader = new ArrowFileReader(stream);
-            Assert.NotNull(reader.ReadNextRecordBatch());
-            Assert.Equal(customMetadata, reader.LastBatchCustomMetadata);
+            RecordBatchWithMetadata read = reader.ReadNextRecordBatchWithCustomMetadata();
+            Assert.NotNull(read.Batch);
+            Assert.Equal(customMetadata, read.CustomMetadata);
+
+            // The indexed read on ArrowFileReader reports the same metadata.
+            RecordBatchWithMetadata indexed = await reader.ReadRecordBatchWithCustomMetadataAsync(0);
+            Assert.NotNull(indexed.Batch);
+            Assert.Equal(customMetadata, indexed.CustomMetadata);
         }
 
         [Fact]
@@ -395,8 +401,9 @@ namespace Apache.Arrow.Tests
 
             stream.Position = 0;
             using var reader = new ArrowFileReader(stream);
-            Assert.NotNull(await reader.ReadNextRecordBatchAsync());
-            Assert.Equal(customMetadata, reader.LastBatchCustomMetadata);
+            RecordBatchWithMetadata read = await reader.ReadNextRecordBatchWithCustomMetadataAsync();
+            Assert.NotNull(read.Batch);
+            Assert.Equal(customMetadata, read.CustomMetadata);
         }
 
         [Fact]

--- a/test/Apache.Arrow.Tests/ArrowFileWriterTests.cs
+++ b/test/Apache.Arrow.Tests/ArrowFileWriterTests.cs
@@ -311,6 +311,114 @@ namespace Apache.Arrow.Tests
             await ValidateRecordBatchFile(stream, recordBatch, strictCompare: false);
         }
 
+        [Fact]
+        public void WriteCustomMetadata_StillWritesFileMagic()
+        {
+            // ArrowFileWriter has to emit the file magic before any message. Regression test for
+            // a WriteRecordBatch overload reaching WriteRecordBatchInternal without it.
+            RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100);
+            var customMetadata = new Dictionary<string, string> { ["batch"] = "first" };
+
+            var stream = new MemoryStream();
+            using (var writer = new ArrowFileWriter(stream, originalBatch.Schema, leaveOpen: true))
+            {
+                writer.WriteRecordBatch(originalBatch, customMetadata);
+                writer.WriteEnd();
+            }
+
+            Assert.Equal(
+                ArrowFileConstants.Magic,
+                stream.ToArray().AsSpan(0, ArrowFileConstants.Magic.Length).ToArray());
+        }
+
+        [Fact]
+        public async Task WriteCustomMetadataAsync_StillWritesFileMagic()
+        {
+            RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100);
+            var customMetadata = new Dictionary<string, string> { ["batch"] = "first" };
+
+            var stream = new MemoryStream();
+            using (var writer = new ArrowFileWriter(stream, originalBatch.Schema, leaveOpen: true))
+            {
+                await writer.WriteRecordBatchAsync(originalBatch, customMetadata);
+                await writer.WriteEndAsync();
+            }
+
+            Assert.Equal(
+                ArrowFileConstants.Magic,
+                stream.ToArray().AsSpan(0, ArrowFileConstants.Magic.Length).ToArray());
+        }
+
+        [Fact]
+        public async Task WriteCustomMetadata_RoundTrips()
+        {
+            RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100);
+            var customMetadata = new Dictionary<string, string>
+            {
+                ["rpc.method"] = "add",
+                ["request_id"] = "abc-123",
+            };
+
+            var stream = new MemoryStream();
+            using (var writer = new ArrowFileWriter(stream, originalBatch.Schema, leaveOpen: true))
+            {
+                writer.WriteRecordBatch(originalBatch, customMetadata);
+                writer.WriteEnd();
+            }
+
+            stream.Position = 0;
+
+            await ValidateRecordBatchFile(stream, originalBatch);
+
+            stream.Position = 0;
+            using var reader = new ArrowFileReader(stream);
+            Assert.NotNull(reader.ReadNextRecordBatch());
+            Assert.Equal(customMetadata, reader.LastBatchCustomMetadata);
+        }
+
+        [Fact]
+        public async Task WriteCustomMetadataAsync_RoundTrips()
+        {
+            RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100);
+            var customMetadata = new Dictionary<string, string> { ["key1"] = "value1" };
+
+            var stream = new MemoryStream();
+            using (var writer = new ArrowFileWriter(stream, originalBatch.Schema, leaveOpen: true))
+            {
+                await writer.WriteRecordBatchAsync(originalBatch, customMetadata);
+                await writer.WriteEndAsync();
+            }
+
+            stream.Position = 0;
+
+            await ValidateRecordBatchFile(stream, originalBatch);
+
+            stream.Position = 0;
+            using var reader = new ArrowFileReader(stream);
+            Assert.NotNull(await reader.ReadNextRecordBatchAsync());
+            Assert.Equal(customMetadata, reader.LastBatchCustomMetadata);
+        }
+
+        [Fact]
+        public async Task WriteCustomMetadata_AfterExplicitWriteStart_RoundTrips()
+        {
+            // WriteStart is idempotent, so writing it up front must not produce a second preamble.
+            RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100);
+            var customMetadata = new Dictionary<string, string> { ["key1"] = "value1" };
+
+            var stream = new MemoryStream();
+            using (var writer = new ArrowFileWriter(stream, originalBatch.Schema, leaveOpen: true))
+            {
+                writer.WriteStart();
+                writer.WriteRecordBatch(originalBatch, customMetadata);
+                writer.WriteEnd();
+            }
+
+            stream.Position = 0;
+
+            await ValidateRecordBatchFile(stream, originalBatch);
+        }
+
         private static void Shuffle(int[] values, Random random)
         {
             var length = values.Length;

--- a/test/Apache.Arrow.Tests/ArrowStreamWriterTests.cs
+++ b/test/Apache.Arrow.Tests/ArrowStreamWriterTests.cs
@@ -736,5 +736,164 @@ namespace Apache.Arrow.Tests
                 Assert.True(allocator.Statistics.Allocations > 0);
             Assert.Equal(0, allocator.Rented);
         }
+
+        [Fact]
+        public void WriteCustomMetadata_RoundTrips()
+        {
+            RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 10);
+            var customMetadata = new Dictionary<string, string>
+            {
+                ["rpc.method"] = "add",
+                ["rpc.version"] = "1",
+                ["request_id"] = "abc-123",
+            };
+
+            using var stream = new MemoryStream();
+            using (var writer = new ArrowStreamWriter(stream, originalBatch.Schema, leaveOpen: true))
+            {
+                writer.WriteRecordBatch(originalBatch, customMetadata);
+                writer.WriteEnd();
+            }
+
+            stream.Position = 0;
+
+            using var reader = new ArrowStreamReader(stream);
+            RecordBatch readBatch = reader.ReadNextRecordBatch();
+            Assert.NotNull(readBatch);
+            ArrowReaderVerifier.CompareBatches(originalBatch, readBatch);
+
+            var readMetadata = reader.LastBatchCustomMetadata;
+            Assert.NotNull(readMetadata);
+            Assert.Equal(3, readMetadata.Count);
+            Assert.Equal("add", readMetadata["rpc.method"]);
+            Assert.Equal("1", readMetadata["rpc.version"]);
+            Assert.Equal("abc-123", readMetadata["request_id"]);
+        }
+
+        [Fact]
+        public async Task WriteCustomMetadataAsync_RoundTrips()
+        {
+            RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 10);
+            var customMetadata = new Dictionary<string, string>
+            {
+                ["key1"] = "value1",
+                ["key2"] = "value2",
+            };
+
+            using var stream = new MemoryStream();
+            using (var writer = new ArrowStreamWriter(stream, originalBatch.Schema, leaveOpen: true))
+            {
+                await writer.WriteRecordBatchAsync(originalBatch, customMetadata);
+                await writer.WriteEndAsync();
+            }
+
+            stream.Position = 0;
+
+            using var reader = new ArrowStreamReader(stream);
+            RecordBatch readBatch = reader.ReadNextRecordBatch();
+            Assert.NotNull(readBatch);
+            ArrowReaderVerifier.CompareBatches(originalBatch, readBatch);
+
+            Assert.NotNull(reader.LastBatchCustomMetadata);
+            Assert.Equal("value1", reader.LastBatchCustomMetadata["key1"]);
+            Assert.Equal("value2", reader.LastBatchCustomMetadata["key2"]);
+        }
+
+        [Fact]
+        public void WriteCustomMetadata_MultipleBatches_EachHasOwnMetadata()
+        {
+            RecordBatch batch = TestData.CreateSampleRecordBatch(length: 5);
+            var meta1 = new Dictionary<string, string> { ["batch"] = "first" };
+            var meta2 = new Dictionary<string, string> { ["batch"] = "second", ["extra"] = "data" };
+
+            using var stream = new MemoryStream();
+            using (var writer = new ArrowStreamWriter(stream, batch.Schema, leaveOpen: true))
+            {
+                writer.WriteRecordBatch(batch, meta1);
+                writer.WriteRecordBatch(batch, meta2);
+                writer.WriteEnd();
+            }
+
+            stream.Position = 0;
+
+            using var reader = new ArrowStreamReader(stream);
+
+            reader.ReadNextRecordBatch();
+            Assert.NotNull(reader.LastBatchCustomMetadata);
+            Assert.Single(reader.LastBatchCustomMetadata);
+            Assert.Equal("first", reader.LastBatchCustomMetadata["batch"]);
+
+            reader.ReadNextRecordBatch();
+            Assert.NotNull(reader.LastBatchCustomMetadata);
+            Assert.Equal(2, reader.LastBatchCustomMetadata.Count);
+            Assert.Equal("second", reader.LastBatchCustomMetadata["batch"]);
+            Assert.Equal("data", reader.LastBatchCustomMetadata["extra"]);
+        }
+
+        [Fact]
+        public void WriteWithoutCustomMetadata_LastBatchCustomMetadataIsNull()
+        {
+            RecordBatch batch = TestData.CreateSampleRecordBatch(length: 5);
+
+            using var stream = new MemoryStream();
+            using (var writer = new ArrowStreamWriter(stream, batch.Schema, leaveOpen: true))
+            {
+                writer.WriteRecordBatch(batch);
+                writer.WriteEnd();
+            }
+
+            stream.Position = 0;
+
+            using var reader = new ArrowStreamReader(stream);
+            reader.ReadNextRecordBatch();
+            Assert.Null(reader.LastBatchCustomMetadata);
+        }
+
+        [Fact]
+        public void WriteCustomMetadata_MixedBatches_WithAndWithoutMetadata()
+        {
+            RecordBatch batch = TestData.CreateSampleRecordBatch(length: 5);
+            var meta = new Dictionary<string, string> { ["key"] = "value" };
+
+            using var stream = new MemoryStream();
+            using (var writer = new ArrowStreamWriter(stream, batch.Schema, leaveOpen: true))
+            {
+                writer.WriteRecordBatch(batch, meta);
+                writer.WriteRecordBatch(batch); // no metadata
+                writer.WriteEnd();
+            }
+
+            stream.Position = 0;
+
+            using var reader = new ArrowStreamReader(stream);
+
+            reader.ReadNextRecordBatch();
+            Assert.NotNull(reader.LastBatchCustomMetadata);
+            Assert.Equal("value", reader.LastBatchCustomMetadata["key"]);
+
+            reader.ReadNextRecordBatch();
+            Assert.Null(reader.LastBatchCustomMetadata);
+        }
+
+        [Fact]
+        public void WriteCustomMetadata_EmptyValues_RoundTrips()
+        {
+            RecordBatch batch = TestData.CreateSampleRecordBatch(length: 5);
+            var meta = new Dictionary<string, string> { ["empty"] = "" };
+
+            using var stream = new MemoryStream();
+            using (var writer = new ArrowStreamWriter(stream, batch.Schema, leaveOpen: true))
+            {
+                writer.WriteRecordBatch(batch, meta);
+                writer.WriteEnd();
+            }
+
+            stream.Position = 0;
+
+            using var reader = new ArrowStreamReader(stream);
+            reader.ReadNextRecordBatch();
+            Assert.NotNull(reader.LastBatchCustomMetadata);
+            Assert.Equal("", reader.LastBatchCustomMetadata["empty"]);
+        }
     }
 }

--- a/test/Apache.Arrow.Tests/ArrowStreamWriterTests.cs
+++ b/test/Apache.Arrow.Tests/ArrowStreamWriterTests.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Buffers.Binary;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -876,6 +877,90 @@ namespace Apache.Arrow.Tests
         }
 
         [Fact]
+        public void WriteCustomMetadata_EmptyDictionary_WritesNoMetadata()
+        {
+            RecordBatch batch = TestData.CreateSampleRecordBatch(length: 5);
+
+            using var stream = new MemoryStream();
+            using (var writer = new ArrowStreamWriter(stream, batch.Schema, leaveOpen: true))
+            {
+                writer.WriteRecordBatch(batch, new Dictionary<string, string>());
+                writer.WriteEnd();
+            }
+
+            stream.Position = 0;
+
+            using var reader = new ArrowStreamReader(stream);
+            reader.ReadNextRecordBatch();
+            Assert.Null(reader.LastBatchCustomMetadata);
+        }
+
+        [Fact]
+        public void WriteCustomMetadata_NullKey_Throws()
+        {
+            RecordBatch batch = TestData.CreateSampleRecordBatch(length: 5);
+            // Dictionary<string, string> rejects a null key, so go through a map that allows one.
+            var withNullKey = new NullTolerantMetadata(new KeyValuePair<string, string>(null, "value"));
+
+            using var stream = new MemoryStream();
+            using var writer = new ArrowStreamWriter(stream, batch.Schema, leaveOpen: true);
+
+            Assert.Throws<ArgumentException>(() => writer.WriteRecordBatch(batch, withNullKey));
+        }
+
+        [Fact]
+        public void WriteCustomMetadata_NullValue_Throws()
+        {
+            RecordBatch batch = TestData.CreateSampleRecordBatch(length: 5);
+            var meta = new Dictionary<string, string> { ["key"] = null };
+
+            using var stream = new MemoryStream();
+            using var writer = new ArrowStreamWriter(stream, batch.Schema, leaveOpen: true);
+
+            Assert.Throws<ArgumentException>(() => writer.WriteRecordBatch(batch, meta));
+        }
+
+        [Fact]
+        public async Task WriteCustomMetadataAsync_NullValue_Throws()
+        {
+            RecordBatch batch = TestData.CreateSampleRecordBatch(length: 5);
+            var meta = new Dictionary<string, string> { ["key"] = null };
+
+            using var stream = new MemoryStream();
+            using var writer = new ArrowStreamWriter(stream, batch.Schema, leaveOpen: true);
+
+            await Assert.ThrowsAsync<ArgumentException>(
+                () => writer.WriteRecordBatchAsync(batch, meta));
+        }
+
+        [Fact]
+        public void WriteCustomMetadata_RejectedMetadata_LeavesWriterUsable()
+        {
+            // Validation happens before anything is written, so a rejected dictionary must not
+            // leave the writer part-way through a message.
+            RecordBatch batch = TestData.CreateSampleRecordBatch(length: 5);
+            var good = new Dictionary<string, string> { ["key"] = "value" };
+            var bad = new Dictionary<string, string> { ["key"] = null };
+
+            using var stream = new MemoryStream();
+            using (var writer = new ArrowStreamWriter(stream, batch.Schema, leaveOpen: true))
+            {
+                Assert.Throws<ArgumentException>(() => writer.WriteRecordBatch(batch, bad));
+                writer.WriteRecordBatch(batch, good);
+                writer.WriteEnd();
+            }
+
+            stream.Position = 0;
+
+            using var reader = new ArrowStreamReader(stream);
+            RecordBatch readBatch = reader.ReadNextRecordBatch();
+            Assert.NotNull(readBatch);
+            ArrowReaderVerifier.CompareBatches(batch, readBatch);
+            Assert.Equal(good, reader.LastBatchCustomMetadata);
+            Assert.Null(reader.ReadNextRecordBatch());
+        }
+
+        [Fact]
         public void WriteCustomMetadata_EmptyValues_RoundTrips()
         {
             RecordBatch batch = TestData.CreateSampleRecordBatch(length: 5);
@@ -894,6 +979,25 @@ namespace Apache.Arrow.Tests
             reader.ReadNextRecordBatch();
             Assert.NotNull(reader.LastBatchCustomMetadata);
             Assert.Equal("", reader.LastBatchCustomMetadata["empty"]);
+        }
+
+        /// <summary>
+        /// A metadata collection that can hold a null key, which <see cref="Dictionary{TKey, TValue}"/> cannot.
+        /// </summary>
+        private sealed class NullTolerantMetadata : IReadOnlyDictionary<string, string>
+        {
+            private readonly KeyValuePair<string, string>[] _entries;
+
+            public NullTolerantMetadata(params KeyValuePair<string, string>[] entries) => _entries = entries;
+
+            public int Count => _entries.Length;
+            public IEnumerable<string> Keys => _entries.Select(e => e.Key);
+            public IEnumerable<string> Values => _entries.Select(e => e.Value);
+            public string this[string key] => throw new NotSupportedException();
+            public bool ContainsKey(string key) => throw new NotSupportedException();
+            public bool TryGetValue(string key, out string value) => throw new NotSupportedException();
+            public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => ((IEnumerable<KeyValuePair<string, string>>)_entries).GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => _entries.GetEnumerator();
         }
     }
 }

--- a/test/Apache.Arrow.Tests/ArrowStreamWriterTests.cs
+++ b/test/Apache.Arrow.Tests/ArrowStreamWriterTests.cs
@@ -759,16 +759,15 @@ namespace Apache.Arrow.Tests
             stream.Position = 0;
 
             using var reader = new ArrowStreamReader(stream);
-            RecordBatch readBatch = reader.ReadNextRecordBatch();
-            Assert.NotNull(readBatch);
-            ArrowReaderVerifier.CompareBatches(originalBatch, readBatch);
+            RecordBatchWithMetadata read = reader.ReadNextRecordBatchWithCustomMetadata();
+            Assert.NotNull(read.Batch);
+            ArrowReaderVerifier.CompareBatches(originalBatch, read.Batch);
 
-            var readMetadata = reader.LastBatchCustomMetadata;
-            Assert.NotNull(readMetadata);
-            Assert.Equal(3, readMetadata.Count);
-            Assert.Equal("add", readMetadata["rpc.method"]);
-            Assert.Equal("1", readMetadata["rpc.version"]);
-            Assert.Equal("abc-123", readMetadata["request_id"]);
+            Assert.NotNull(read.CustomMetadata);
+            Assert.Equal(3, read.CustomMetadata.Count);
+            Assert.Equal("add", read.CustomMetadata["rpc.method"]);
+            Assert.Equal("1", read.CustomMetadata["rpc.version"]);
+            Assert.Equal("abc-123", read.CustomMetadata["request_id"]);
         }
 
         [Fact]
@@ -791,13 +790,12 @@ namespace Apache.Arrow.Tests
             stream.Position = 0;
 
             using var reader = new ArrowStreamReader(stream);
-            RecordBatch readBatch = reader.ReadNextRecordBatch();
+            (RecordBatch readBatch, IReadOnlyDictionary<string, string> readMetadata) =
+                await reader.ReadNextRecordBatchWithCustomMetadataAsync();
             Assert.NotNull(readBatch);
             ArrowReaderVerifier.CompareBatches(originalBatch, readBatch);
 
-            Assert.NotNull(reader.LastBatchCustomMetadata);
-            Assert.Equal("value1", reader.LastBatchCustomMetadata["key1"]);
-            Assert.Equal("value2", reader.LastBatchCustomMetadata["key2"]);
+            Assert.Equal(customMetadata, readMetadata);
         }
 
         [Fact]
@@ -819,20 +817,12 @@ namespace Apache.Arrow.Tests
 
             using var reader = new ArrowStreamReader(stream);
 
-            reader.ReadNextRecordBatch();
-            Assert.NotNull(reader.LastBatchCustomMetadata);
-            Assert.Single(reader.LastBatchCustomMetadata);
-            Assert.Equal("first", reader.LastBatchCustomMetadata["batch"]);
-
-            reader.ReadNextRecordBatch();
-            Assert.NotNull(reader.LastBatchCustomMetadata);
-            Assert.Equal(2, reader.LastBatchCustomMetadata.Count);
-            Assert.Equal("second", reader.LastBatchCustomMetadata["batch"]);
-            Assert.Equal("data", reader.LastBatchCustomMetadata["extra"]);
+            Assert.Equal(meta1, reader.ReadNextRecordBatchWithCustomMetadata().CustomMetadata);
+            Assert.Equal(meta2, reader.ReadNextRecordBatchWithCustomMetadata().CustomMetadata);
         }
 
         [Fact]
-        public void WriteWithoutCustomMetadata_LastBatchCustomMetadataIsNull()
+        public void WriteWithoutCustomMetadata_CustomMetadataIsNull()
         {
             RecordBatch batch = TestData.CreateSampleRecordBatch(length: 5);
 
@@ -846,8 +836,9 @@ namespace Apache.Arrow.Tests
             stream.Position = 0;
 
             using var reader = new ArrowStreamReader(stream);
-            reader.ReadNextRecordBatch();
-            Assert.Null(reader.LastBatchCustomMetadata);
+            RecordBatchWithMetadata read = reader.ReadNextRecordBatchWithCustomMetadata();
+            Assert.NotNull(read.Batch);
+            Assert.Null(read.CustomMetadata);
         }
 
         [Fact]
@@ -868,12 +859,16 @@ namespace Apache.Arrow.Tests
 
             using var reader = new ArrowStreamReader(stream);
 
-            reader.ReadNextRecordBatch();
-            Assert.NotNull(reader.LastBatchCustomMetadata);
-            Assert.Equal("value", reader.LastBatchCustomMetadata["key"]);
+            Assert.Equal(meta, reader.ReadNextRecordBatchWithCustomMetadata().CustomMetadata);
 
-            reader.ReadNextRecordBatch();
-            Assert.Null(reader.LastBatchCustomMetadata);
+            RecordBatchWithMetadata second = reader.ReadNextRecordBatchWithCustomMetadata();
+            Assert.NotNull(second.Batch);
+            Assert.Null(second.CustomMetadata);
+
+            // At the end of the stream both halves are null, not the previous batch's metadata.
+            RecordBatchWithMetadata end = reader.ReadNextRecordBatchWithCustomMetadata();
+            Assert.Null(end.Batch);
+            Assert.Null(end.CustomMetadata);
         }
 
         [Fact]
@@ -891,8 +886,9 @@ namespace Apache.Arrow.Tests
             stream.Position = 0;
 
             using var reader = new ArrowStreamReader(stream);
-            reader.ReadNextRecordBatch();
-            Assert.Null(reader.LastBatchCustomMetadata);
+            RecordBatchWithMetadata read = reader.ReadNextRecordBatchWithCustomMetadata();
+            Assert.NotNull(read.Batch);
+            Assert.Null(read.CustomMetadata);
         }
 
         [Fact]
@@ -953,10 +949,10 @@ namespace Apache.Arrow.Tests
             stream.Position = 0;
 
             using var reader = new ArrowStreamReader(stream);
-            RecordBatch readBatch = reader.ReadNextRecordBatch();
-            Assert.NotNull(readBatch);
-            ArrowReaderVerifier.CompareBatches(batch, readBatch);
-            Assert.Equal(good, reader.LastBatchCustomMetadata);
+            RecordBatchWithMetadata read = reader.ReadNextRecordBatchWithCustomMetadata();
+            Assert.NotNull(read.Batch);
+            ArrowReaderVerifier.CompareBatches(batch, read.Batch);
+            Assert.Equal(good, read.CustomMetadata);
             Assert.Null(reader.ReadNextRecordBatch());
         }
 
@@ -976,9 +972,10 @@ namespace Apache.Arrow.Tests
             stream.Position = 0;
 
             using var reader = new ArrowStreamReader(stream);
-            reader.ReadNextRecordBatch();
-            Assert.NotNull(reader.LastBatchCustomMetadata);
-            Assert.Equal("", reader.LastBatchCustomMetadata["empty"]);
+            IReadOnlyDictionary<string, string> readMetadata =
+                reader.ReadNextRecordBatchWithCustomMetadata().CustomMetadata;
+            Assert.NotNull(readMetadata);
+            Assert.Equal("", readMetadata["empty"]);
         }
 
         /// <summary>

--- a/test/Apache.Arrow.Tests/CustomMetadataPythonTests.cs
+++ b/test/Apache.Arrow.Tests/CustomMetadataPythonTests.cs
@@ -1,0 +1,183 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Apache.Arrow.Ipc;
+using Python.Runtime;
+using Xunit;
+
+namespace Apache.Arrow.Tests
+{
+
+    // -------------------------------------------------------------------
+    // Cross-language Python tests for custom_metadata
+    // -------------------------------------------------------------------
+
+    public class CustomMetadataPythonTests : IClassFixture<CustomMetadataPythonTests.PythonNet>
+    {
+        public class PythonNet : IDisposable
+        {
+            public bool Initialized { get; }
+
+            public bool VersionMismatch { get; }
+
+            public PythonNet()
+            {
+                bool pythonSet = Environment.GetEnvironmentVariable("PYTHONNET_PYDLL") != null;
+                if (!pythonSet)
+                {
+                    Initialized = false;
+                    return;
+                }
+
+                try
+                {
+                    PythonEngine.Initialize();
+                }
+                catch (NotSupportedException e) when (e.Message.Contains("Python ABI ") && e.Message.Contains("not supported"))
+                {
+                    Initialized = false;
+                    VersionMismatch = true;
+                    return;
+                }
+
+                if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows) &&
+                    PythonEngine.PythonPath.IndexOf("dlls", StringComparison.OrdinalIgnoreCase) < 0)
+                {
+                    dynamic sys = Py.Import("sys");
+                    sys.path.append(Path.Combine(Path.GetDirectoryName(Environment.GetEnvironmentVariable("PYTHONNET_PYDLL")), "DLLs"));
+                }
+
+                Initialized = true;
+            }
+
+            public void Dispose()
+            {
+                PythonEngine.Shutdown();
+            }
+        }
+
+        public CustomMetadataPythonTests(PythonNet pythonNet)
+        {
+            if (!pythonNet.Initialized)
+            {
+                var errorReason = pythonNet.VersionMismatch ? "Python version is incompatible with PythonNet" : "PYTHONNET_PYDLL not set";
+
+                bool inCIJob = Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true";
+                bool inVerificationJob = Environment.GetEnvironmentVariable("TEST_CSHARP") == "1";
+
+                Skip.If(inVerificationJob || !inCIJob, $"{errorReason}; skipping custom metadata Python tests.");
+
+                throw new Exception($"{errorReason}; cannot run custom metadata Python tests.");
+            }
+        }
+
+        // -------------------------------------------------------------------
+        // C# writes IPC with custom_metadata → Python reads
+        // -------------------------------------------------------------------
+
+        [SkippableFact]
+        public void ExportCustomMetadata_PythonReads()
+        {
+            RecordBatch batch = TestData.CreateSampleRecordBatch(length: 5);
+            var batchMetadata = new Dictionary<string, string>
+            {
+                ["rpc.method"] = "greet",
+                ["request_id"] = "abc-123",
+                ["custom_key"] = "custom_value",
+            };
+
+            // Serialize to IPC stream with custom batch metadata
+            byte[] ipcBytes;
+            using (var ms = new MemoryStream())
+            {
+                using (var writer = new ArrowStreamWriter(ms, batch.Schema, leaveOpen: true))
+                {
+                    writer.WriteRecordBatch(batch, batchMetadata);
+                    writer.WriteEnd();
+                }
+                ipcBytes = ms.ToArray();
+            }
+
+            // Python reads and verifies custom_metadata
+            using (Py.GIL())
+            {
+                dynamic pa = Py.Import("pyarrow");
+                dynamic reader = pa.ipc.open_stream(pa.BufferReader(ipcBytes.ToPython()));
+
+                PyObject result = reader.read_next_batch_with_custom_metadata();
+                dynamic pyBatch = result[0];
+                dynamic customMeta = result[1];
+
+                // Verify batch data round-tripped
+                Assert.Equal(5, (int)pyBatch.num_rows);
+
+                // Verify custom_metadata (pyarrow returns bytes — decode to str)
+                Assert.Equal("greet", (string)customMeta["rpc.method"].decode());
+                Assert.Equal("abc-123", (string)customMeta["request_id"].decode());
+                Assert.Equal("custom_value", (string)customMeta["custom_key"].decode());
+            }
+        }
+
+        // -------------------------------------------------------------------
+        // Python writes IPC with custom_metadata → C# reads
+        // -------------------------------------------------------------------
+
+        [SkippableFact]
+        public void ImportCustomMetadata_PythonWrites()
+        {
+            byte[] ipcBytes;
+
+            // Python creates a batch with custom_metadata and serializes to IPC
+            using (Py.GIL())
+            {
+                dynamic pa = Py.Import("pyarrow");
+                dynamic io = Py.Import("io");
+
+                dynamic pyBatch = pa.record_batch(new PyList(new PyObject[]
+                {
+                    pa.array(new int[] { 1, 2, 3, 4, 5 }),
+                }), new[] { "x" });
+
+                dynamic buf = io.BytesIO();
+                dynamic writer = pa.ipc.new_stream(buf, pyBatch.schema);
+                dynamic customMeta = pa.KeyValueMetadata(new PyDict
+                {
+                    ["origin"] = "python".ToPython(),
+                    ["version"] = "2".ToPython(),
+                });
+                writer.write_batch(pyBatch, custom_metadata: customMeta);
+                writer.close();
+
+                ipcBytes = ((PyObject)buf.getvalue()).As<byte[]>();
+            }
+
+            // C# reads and verifies custom_metadata
+            using var ms = new MemoryStream(ipcBytes);
+            using var reader = new ArrowStreamReader(ms);
+
+            RecordBatch batch = reader.ReadNextRecordBatch();
+            Assert.NotNull(batch);
+            Assert.Equal(5, batch.Length);
+
+            var metadata = reader.LastBatchCustomMetadata;
+            Assert.NotNull(metadata);
+            Assert.Equal("python", metadata["origin"]);
+            Assert.Equal("2", metadata["version"]);
+        }
+    }
+}

--- a/test/Apache.Arrow.Tests/CustomMetadataPythonTests.cs
+++ b/test/Apache.Arrow.Tests/CustomMetadataPythonTests.cs
@@ -119,11 +119,11 @@ namespace Apache.Arrow.Tests
             using var ms = new MemoryStream(ipcBytes);
             using var reader = new ArrowStreamReader(ms);
 
-            RecordBatch batch = reader.ReadNextRecordBatch();
+            (RecordBatch batch, IReadOnlyDictionary<string, string> metadata) =
+                reader.ReadNextRecordBatchWithCustomMetadata();
             Assert.NotNull(batch);
             Assert.Equal(5, batch.Length);
 
-            var metadata = reader.LastBatchCustomMetadata;
             Assert.NotNull(metadata);
             Assert.Equal("python", metadata["origin"]);
             Assert.Equal("2", metadata["version"]);

--- a/test/Apache.Arrow.Tests/CustomMetadataPythonTests.cs
+++ b/test/Apache.Arrow.Tests/CustomMetadataPythonTests.cs
@@ -27,63 +27,12 @@ namespace Apache.Arrow.Tests
     // Cross-language Python tests for custom_metadata
     // -------------------------------------------------------------------
 
-    public class CustomMetadataPythonTests : IClassFixture<CustomMetadataPythonTests.PythonNet>
+    [Collection("PythonNet")]
+    public class CustomMetadataPythonTests
     {
-        public class PythonNet : IDisposable
+        public CustomMetadataPythonTests(PythonNetFixture pythonNet)
         {
-            public bool Initialized { get; }
-
-            public bool VersionMismatch { get; }
-
-            public PythonNet()
-            {
-                bool pythonSet = Environment.GetEnvironmentVariable("PYTHONNET_PYDLL") != null;
-                if (!pythonSet)
-                {
-                    Initialized = false;
-                    return;
-                }
-
-                try
-                {
-                    PythonEngine.Initialize();
-                }
-                catch (NotSupportedException e) when (e.Message.Contains("Python ABI ") && e.Message.Contains("not supported"))
-                {
-                    Initialized = false;
-                    VersionMismatch = true;
-                    return;
-                }
-
-                if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows) &&
-                    PythonEngine.PythonPath.IndexOf("dlls", StringComparison.OrdinalIgnoreCase) < 0)
-                {
-                    dynamic sys = Py.Import("sys");
-                    sys.path.append(Path.Combine(Path.GetDirectoryName(Environment.GetEnvironmentVariable("PYTHONNET_PYDLL")), "DLLs"));
-                }
-
-                Initialized = true;
-            }
-
-            public void Dispose()
-            {
-                PythonEngine.Shutdown();
-            }
-        }
-
-        public CustomMetadataPythonTests(PythonNet pythonNet)
-        {
-            if (!pythonNet.Initialized)
-            {
-                var errorReason = pythonNet.VersionMismatch ? "Python version is incompatible with PythonNet" : "PYTHONNET_PYDLL not set";
-
-                bool inCIJob = Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true";
-                bool inVerificationJob = Environment.GetEnvironmentVariable("TEST_CSHARP") == "1";
-
-                Skip.If(inVerificationJob || !inCIJob, $"{errorReason}; skipping custom metadata Python tests.");
-
-                throw new Exception($"{errorReason}; cannot run custom metadata Python tests.");
-            }
+            pythonNet.EnsureInitialized();
         }
 
         // -------------------------------------------------------------------


### PR DESCRIPTION
Adds IPC `Message.custom_metadata` support to the stream and file readers and writers.

## Credit

The original implementation is **@cmettler's** work in #283 (closing #282). **@rustyconover** rebased it onto a `main` that had drifted ~76 commits ahead and addressed the first round of review comments in #424. Both of those PRs are branches on personal forks; this one moves the work onto a branch in the base repository so that any committer can push to it, and supersedes them. The individual commits here retain their original authorship.

## What this adds

- `ArrowStreamReader.ReadNextRecordBatchWithCustomMetadata()` and `…Async()` return a `RecordBatchWithMetadata` pairing the batch with its IPC `Message.custom_metadata`, mirroring pyarrow's `read_next_batch_with_custom_metadata()` and the equivalent Arrow C++ struct. The struct deconstructs, so callers can write `var (batch, metadata) = …`.
- `ArrowFileReader.ReadRecordBatchWithCustomMetadataAsync(int index)` gives the indexed read the same capability as the sequential one.
- `ArrowStreamWriter.WriteRecordBatch(batch, customMetadata)` and the async counterpart attach per-message `custom_metadata` when writing, matching pyarrow's `write_batch(batch, custom_metadata)`.
- Cross-language round-trip tests via pythonnet + pyarrow, skipped unless `PYTHONNET_PYDLL` is set, consistent with the existing `CDataSchemaPythonTest` pattern.

## Changes on top of #424

- The read side originally exposed a `LastBatchCustomMetadata` property. A property that has to be read at exactly the right moment is easy to get out of step with the batch in hand, and it had no sensible value at the end of the stream, so it was replaced with the `RecordBatchWithMetadata` return type above. The transient state on `ArrowReaderImplementation` remains, but it is internal and consumed immediately.
- The new write overloads went straight to `WriteRecordBatchInternal`, while `ArrowFileWriter` relied on overriding each public `WriteRecordBatch` to call `WriteStart()` first — so the new overload on an `ArrowFileWriter` skipped the ARROW1 magic and silently produced a file that `ArrowFileReader` rejects. `WriteStart()`/`WriteStartAsync()` moved into `WriteRecordBatchInternal`, where every write path must pass through it; both are idempotent, so byte output is unchanged for the stream writer, the file writer and Flight.
- Removed the second virtual `WriteMessageAsync` overload. Two virtual overloads where one forwards to the other is the trap that already routed Flight's record batch writes past `FlightDataStream`'s override.
- Custom metadata is validated before anything is written rather than part-way through building the message, so a rejected dictionary leaves the writer usable.
- `Message.custom_metadata` is read the same way schema and field metadata already are in `MessageSerializer`, rather than skipping null keys and rewriting null values as `""`.

## Verification

- `dotnet build Apache.Arrow.sln` — succeeds, 0 warnings, 0 errors.
- `dotnet test test/Apache.Arrow.Tests` — 1893 passed / 30 skipped on net8.0, 1849 passed / 30 skipped on net462 and net472, 0 failed. The skips are the pre-existing Python-dependent tests.

Closes #282
Supersedes #283
Supersedes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DT86mdkGm3XseKwiUeGUcx

Co-Authored-By: Christoph Mettler <116812500+cmettler@users.noreply.github.com>
Co-Authored-By: Rusty Conover <rusty@conover.me>
